### PR TITLE
Temporarily remove the part of kclvm resolver that kill the kclvm process

### DIFF
--- a/kclvm/Cargo.lock
+++ b/kclvm/Cargo.lock
@@ -431,6 +431,7 @@ dependencies = [
  "kclvm-ast",
  "kclvm-compiler",
  "kclvm-config",
+ "kclvm-error",
  "kclvm-parser",
  "kclvm-runner",
  "kclvm-runtime",

--- a/kclvm/Cargo.toml
+++ b/kclvm/Cargo.toml
@@ -36,3 +36,4 @@ kclvm-runtime = {path = "./runtime", version = "0.1.0"}
 kclvm-sema = {path = "./sema", version = "0.1.0"}
 kclvm-tools = {path = "./tools", version = "0.1.0"}
 kclvm-version = {path = "./version", version = "0.1.0"}
+kclvm-error = {path = "./error", version = "0.1.0"}

--- a/kclvm/config/Cargo.lock
+++ b/kclvm/config/Cargo.lock
@@ -243,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.6.6"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86018df177b1beef6c7c8ef949969c4f7cb9a9344181b92486b23c79995bdaa4"
+checksum = "1b861ecaade43ac97886a512b360d01d66be9f41f3c61088b42cedf92e03d678"
 dependencies = [
  "base64",
  "bitflags",

--- a/kclvm/error/src/lib.rs
+++ b/kclvm/error/src/lib.rs
@@ -101,6 +101,11 @@ impl Handler {
         }
     }
 
+    /// Emit all diagnostics but do not abort.
+    pub fn alert_if_any_errors(&mut self) {
+        self.emit();
+    }
+
     /// Construct a parse error and put it into the handler diagnostic buffer
     pub fn add_syntex_error(&mut self, msg: &str, pos: Position) -> &mut Self {
         let message = format!("Invalid syntax: {}", msg);

--- a/kclvm/parser/Cargo.lock
+++ b/kclvm/parser/Cargo.lock
@@ -923,9 +923,9 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.6.6"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86018df177b1beef6c7c8ef949969c4f7cb9a9344181b92486b23c79995bdaa4"
+checksum = "1b861ecaade43ac97886a512b360d01d66be9f41f3c61088b42cedf92e03d678"
 dependencies = [
  "base64",
  "bitflags",

--- a/kclvm/runner/Cargo.lock
+++ b/kclvm/runner/Cargo.lock
@@ -1027,9 +1027,9 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.6.6"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86018df177b1beef6c7c8ef949969c4f7cb9a9344181b92486b23c79995bdaa4"
+checksum = "1b861ecaade43ac97886a512b360d01d66be9f41f3c61088b42cedf92e03d678"
 dependencies = [
  "base64",
  "bitflags",

--- a/kclvm/sema/Cargo.lock
+++ b/kclvm/sema/Cargo.lock
@@ -1082,9 +1082,9 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.6.6"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86018df177b1beef6c7c8ef949969c4f7cb9a9344181b92486b23c79995bdaa4"
+checksum = "1b861ecaade43ac97886a512b360d01d66be9f41f3c61088b42cedf92e03d678"
 dependencies = [
  "base64",
  "bitflags",

--- a/kclvm/sema/src/resolver/mod.rs
+++ b/kclvm/sema/src/resolver/mod.rs
@@ -78,6 +78,7 @@ impl<'ctx> Resolver<'ctx> {
         ProgramScope {
             scope_map: self.scope_map.clone(),
             import_names: self.ctx.import_names.clone(),
+            diagnostics: self.handler.diagnostics.clone()
         }
     }
 }
@@ -131,7 +132,6 @@ pub fn resolve_program(program: &mut Program) -> ProgramScope {
         },
     );
     let scope = resolver.check(kclvm_ast::MAIN_PKG);
-    resolver.handler.abort_if_any_errors();
     let type_alias_mapping = resolver.ctx.type_alias_mapping.clone();
     process_program_type_alias(program, type_alias_mapping);
     scope

--- a/kclvm/sema/src/resolver/scope.rs
+++ b/kclvm/sema/src/resolver/scope.rs
@@ -1,5 +1,7 @@
 use indexmap::IndexMap;
+use indexmap::IndexSet;
 use kclvm_ast::{ast, MAIN_PKG};
+use kclvm_error::Diagnostic;
 use std::{
     cell::RefCell,
     rc::{Rc, Weak},
@@ -191,6 +193,7 @@ impl Scope {
 pub struct ProgramScope {
     pub scope_map: IndexMap<String, Rc<RefCell<Scope>>>,
     pub import_names: IndexMap<String, IndexMap<String, String>>,
+    pub diagnostics: IndexSet<Diagnostic>,
 }
 
 impl ProgramScope {


### PR DESCRIPTION
Note:
1. This is just a temporary adjustment when the kclvm exception
   throwing mechanism is not completed, and there will be a new
   solution to replace it soon.

What:
1. Change the process of kclvm resolver "finding errors and kill the kclvm
   process in kclvm resolver" to "finding and collecting errors in kclvm
   resolver, and return the errors to the main method for warning".
   Do not kill the kclvm process.

How:
1. Removed the call to method 'handler.abort_if_any_errors()' in method
   'kclvm_sema.resolver.resolve_program'.
2. Add 'diagnostics: IndexSet<Diagnostic>' to 'struct ProgramScope' and
   set the value for 'diagnostics' in method 'kclvm_sema.resolver.resolve_program'.
3. Add method 'check_scope_diagnostics' and call it in method 'main'.

Why:
1. The development of kcl-vet relies on the exception throwing mechanism
   of kclvm. Killing the program process after report an error will cause
   the development of kcl-vet to fail to catch the error. Therefore, it
   is necessary to remove the "exit(1)" in the code, let the program run
   normally, and throw the error out.

- With pull requests:
  - Open your pull request against `main`
  - Your pull request should have no more than two commits, if not you should squash them.
  - It should pass all tests in the available continuous integration systems such as GitHub Actions.
  - You should add/modify tests to cover your proposed code changes.
  - If your pull request contains a new feature, please document it on the README.
