### PR TITLE
refactor: adjusted some macros in kclvm-parser and add some methods in kclvm-ast.

### DIFF
--- a/.github/workflows/main_windows.yml
+++ b/.github/workflows/main_windows.yml
@@ -1,0 +1,30 @@
+name: build-and-test-windows
+on: push
+jobs:
+  build-and-test:
+    runs-on: windows-2019
+    env:
+      LLVM_SYS_120_PREFIX: "C:/LLVM"
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+
+      - run: Rename-Item "C:/Program Files/LLVM" "C:/Program Files/LLVM-old"
+
+      # Install LLVM-12
+      - run: Invoke-WebRequest -Uri https://github.com/KusionStack/llvm-package-windows/releases/download/v12.0.1/LLVM-12.0.1-win64.7z -OutFile C:/LLVM-12.0.1-win64.7z
+      - run: Get-FileHash -Algorithm MD5 C:/LLVM-12.0.1-win64.7z # md5: 3fcf77f82c6c3ee650711439b20aebe5
+      - run: 7z x -y C:/LLVM-12.0.1-win64.7z -o"C:/LLVM"
+      - run: Remove-Item C:/LLVM-12.0.1-win64.7z
+
+      - run: echo "C:/LLVM/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - run: clang --version
+      - run: cargo --version
+
+      - name: Run cargo build
+        working-directory: ./kclvm
+        run: cargo build --release
+
+      - run: ./kclvm/target/release/kclvm_cli.exe -h
+

--- a/internal/kclvm_py/program/exec/kclvm_cli.py
+++ b/internal/kclvm_py/program/exec/kclvm_cli.py
@@ -33,15 +33,15 @@ def init_cli_dll():
 
     if platform.system() == "Darwin":
         _exe_root = os.path.dirname(os.path.dirname(sys.executable))
-        _cli_dll_path = f"{_exe_root}/bin/libkclvm_cli.dylib"
+        _cli_dll_path = f"{_exe_root}/bin/libkclvm_cli_cdylib.dylib"
         _cli_dll = CDLL(_cli_dll_path)
     elif platform.system() == "Linux":
         _exe_root = os.path.dirname(os.path.dirname(sys.executable))
-        _cli_dll_path = f"{_exe_root}/bin/libkclvm_cli.so"
+        _cli_dll_path = f"{_exe_root}/bin/libkclvm_cli_cdylib.so"
         _cli_dll = CDLL(_cli_dll_path)
     elif platform.system() == "Windows":
         _exe_root = os.path.dirname(sys.executable)
-        _cli_dll_path = f"{_exe_root}/kclvm_cli.dll"
+        _cli_dll_path = f"{_exe_root}/kclvm_cli_cdylib.dll"
         _cli_dll = CDLL(_cli_dll_path)
     else:
         raise f"unknown os: {platform.system()}"

--- a/internal/kclvm_py/scripts/update-kclvm.sh
+++ b/internal/kclvm_py/scripts/update-kclvm.sh
@@ -57,22 +57,22 @@ cp ./target/release/kclvm_cli $kclvm_install_dir/bin/kclvm_cli
 # libkclvm_cli
 
 # Darwin dylib
-if [ -e target/release/libkclvm_cli.dylib ]; then
-    touch $kclvm_install_dir/bin/libkclvm_cli.dylib
-    rm $kclvm_install_dir/bin/libkclvm_cli.dylib
-    cp target/release/libkclvm_cli.dylib $kclvm_install_dir/bin/libkclvm_cli.dylib
+if [ -e target/release/libkclvm_cli_cdylib.dylib ]; then
+    touch $kclvm_install_dir/bin/libkclvm_cli_cdylib.dylib
+    rm $kclvm_install_dir/bin/libkclvm_cli_cdylib.dylib
+    cp target/release/libkclvm_cli_cdylib.dylib $kclvm_install_dir/bin/libkclvm_cli_cdylib.dylib
 fi
 # Linux so
-if [ -e target/release/libkclvm_cli.so ]; then
-    touch $kclvm_install_dir/bin/libkclvm_cli.so
-    rm $kclvm_install_dir/bin/libkclvm_cli.so
-    cp target/release/libkclvm_cli.so $kclvm_install_dir/bin/libkclvm_cli.so
+if [ -e target/release/libkclvm_cli_cdylib.so ]; then
+    touch $kclvm_install_dir/bin/libkclvm_cli_cdylib.so
+    rm $kclvm_install_dir/bin/libkclvm_cli_cdylib.so
+    cp target/release/libkclvm_cli_cdylib.so $kclvm_install_dir/bin/libkclvm_cli_cdylib.so
 fi
 # Windows dll
-if [ -e target/release/libkclvm_cli.dll ]; then
-    touch $kclvm_install_dir/bin/libkclvm_cli.dll
-    rm $kclvm_install_dir/bin/libkclvm_cli.dll
-    cp target/release/libkclvm_cli.dll $kclvm_install_dir/bin/libkclvm_cli.dll
+if [ -e target/release/libkclvm_cli_cdylib.dll ]; then
+    touch $kclvm_install_dir/bin/libkclvm_cli_cdylib.dll
+    rm $kclvm_install_dir/bin/libkclvm_cli_cdylib.dll
+    cp target/release/libkclvm_cli_cdylib.dll $kclvm_install_dir/bin/libkclvm_cli_cdylib.dll
 fi
 
 

--- a/kclvm/3rdparty/rustc_data_structures/src/flock.rs
+++ b/kclvm/3rdparty/rustc_data_structures/src/flock.rs
@@ -11,6 +11,9 @@ use std::fs::{File, OpenOptions};
 use std::io;
 use std::path::Path;
 
+#[cfg(target_os = "windows")]
+use tracing::debug;
+
 cfg_if! {
     // We use `flock` rather than `fcntl` on Linux, because WSL1 does not support
     // `fcntl`-style advisory locks properly (rust-lang/rust#72157).

--- a/kclvm/Cargo.lock
+++ b/kclvm/Cargo.lock
@@ -583,6 +583,7 @@ dependencies = [
  "indexmap",
  "itertools",
  "json_minimal",
+ "kclvm-ast",
  "kclvm_runtime_internal_macros",
  "libc",
  "md5",

--- a/kclvm/Cargo.toml
+++ b/kclvm/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib"]
 path = "src/lib.rs"
-name = "kclvm_cli"
+name = "kclvm_cli_cdylib"
 
 [[bin]]
 path = "src/main.rs"

--- a/kclvm/ast/src/ast.rs
+++ b/kclvm/ast/src/ast.rs
@@ -42,6 +42,8 @@ use kclvm_span::Loc;
 use rustc_span::Pos;
 
 use super::token;
+use crate::node_ref;
+use crate::quoted_string;
 
 /// Node is the file, line and column number information
 /// that all AST nodes need to contain.
@@ -223,6 +225,19 @@ pub struct Module {
     pub name: String,
     pub body: Vec<NodeRef<Stmt>>,
     pub comments: Vec<NodeRef<Comment>>,
+}
+
+impl Module {
+    /// Get all ast.schema_stmts from ast.module and return it in a Vec.
+    pub fn filter_schema_stmt_from_module(&self) -> Vec<NodeRef<SchemaStmt>> {
+        let mut stmts = Vec::new();
+        for stmt in &self.body {
+            if let Stmt::Schema(schema_stmt) = &stmt.node {
+                stmts.push(node_ref!(schema_stmt.clone()));
+            }
+        }
+        return stmts;
+    }
 }
 
 /*
@@ -998,6 +1013,21 @@ pub struct StringLit {
     pub value: String,
 }
 
+/// Generate ast.StringLit from String
+impl TryFrom<String> for StringLit {
+    type Error = &'static str;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Ok(
+            Self{
+                value: value.clone(),
+                raw_value: quoted_string(&value),
+                is_long_string: false
+            }
+        )
+    }
+}
+
 /// NameConstant, e.g.
 /// ```kcl
 /// True
@@ -1020,6 +1050,18 @@ impl NameConstant {
             NameConstant::False => "False",
             NameConstant::None => "None",
             NameConstant::Undefined => "Undefined",
+        }
+    }
+}
+
+/// Generate ast.NameConstant from Bool
+impl TryFrom<bool> for NameConstant {
+    type Error = &'static str;
+
+    fn try_from(value: bool) -> Result<Self, Self::Error> {
+        match value {
+            true => Ok(NameConstant::True),
+            false => Ok(NameConstant::False),
         }
     }
 }

--- a/kclvm/ast/src/lib.rs
+++ b/kclvm/ast/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright 2021 The KCL Authors. All rights reserved.
+use crate::ast::*;
 
 pub mod ast;
 pub mod token;
@@ -9,3 +10,63 @@ pub mod walker;
 mod tests;
 
 pub const MAIN_PKG: &str = "__main__";
+
+#[macro_export]
+macro_rules! node_ref {
+    ($node: expr) => {
+        NodeRef::new(Node::dummy_node($node))
+    };
+    ($node: expr, $pos:expr) => {
+        NodeRef::new(Node::node_with_pos($node, $pos))
+    };
+}
+
+#[macro_export]
+macro_rules! expr_as {
+    ($expr: expr, $expr_enum: path) => {
+        if let $expr_enum(x) = ($expr.node as Expr) {
+            Some(x)
+        } else {
+            None
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! stmt_as {
+    ($stmt: expr, $stmt_enum: path) => {
+        if let $stmt_enum(x) = ($stmt.node as Stmt) {
+            Some(x)
+        } else {
+            None
+        }
+    };
+}
+
+/// Construct an AssignStmt node with assign_value as value
+pub fn build_assign_node(attr_name: &str, assign_value: NodeRef<Expr>) -> NodeRef<Stmt> {
+    let iden = node_ref!(Identifier {
+        names: vec![attr_name.to_string()],
+        pkgpath: String::new(),
+        ctx: ExprContext::Store
+    });
+
+    node_ref!(Stmt::Assign(AssignStmt {
+        value: assign_value,
+        targets: vec![iden],
+        type_annotation: None,
+        ty: None
+    }))
+}
+/// Convert a Rust string to a quoted string e.g., abc -> 'abc'
+pub fn quoted_string(value: &str) -> String {
+    let has_double_quote = value.contains('\'');
+    let has_single_quote = value.contains('\"');
+    if !has_single_quote {
+        format!("'{}'", value)
+    } else if !has_double_quote {
+        format!("\"{}\"", value)
+    } else {
+        format!("\"{}\"", value.replace("\"", "\\\""))
+    }
+}

--- a/kclvm/ast/src/tests.rs
+++ b/kclvm/ast/src/tests.rs
@@ -1,5 +1,7 @@
-use crate::ast;
 use crate::walker::MutSelfMutWalker;
+use crate::AugOp::Mod;
+use crate::{ast, build_assign_node, node_ref, Identifier, Module, Node, NodeRef, SchemaStmt};
+use std::process::id;
 
 fn get_dummy_assign_ast() -> ast::Node<ast::AssignStmt> {
     let filename = "main.k";
@@ -139,4 +141,128 @@ fn test_mut_walker() {
     let mut assign_stmt = get_dummy_assign_ast();
     VarMutSelfMutWalker {}.walk_assign_stmt(&mut assign_stmt.node);
     assert_eq!(assign_stmt.node.targets[0].node.names[0], "x")
+}
+
+#[test]
+fn test_try_from_for_stringlit() {
+    let str_lit = ast::StringLit::try_from("test_str".to_string()).unwrap();
+    let json_str = serde_json::to_string(&str_lit).unwrap();
+
+    let str_expected =
+        "{\"is_long_string\":false,\"raw_value\":\"'test_str'\",\"value\":\"test_str\"}".to_string();
+    assert_eq!(str_expected, json_str);
+}
+
+#[test]
+fn test_try_from_for_nameconstant() {
+    let name_cons = ast::NameConstant::try_from(true).unwrap();
+    let json_str = serde_json::to_string(&name_cons).unwrap();
+    assert_eq!("\"True\"", json_str);
+
+    let name_cons = ast::NameConstant::try_from(false).unwrap();
+    let json_str = serde_json::to_string(&name_cons).unwrap();
+    assert_eq!("\"False\"", json_str);
+}
+
+#[test]
+fn test_filter_schema_with_no_schema() {
+    let ast_mod = Module {
+        filename: "".to_string(),
+        pkg: "".to_string(),
+        doc: "".to_string(),
+        name: "".to_string(),
+        body: vec![],
+        comments: vec![],
+    };
+    let schema_stmts = ast_mod.filter_schema_stmt_from_module();
+    assert_eq!(schema_stmts.len(), 0);
+}
+
+#[test]
+fn test_filter_schema_with_one_schema() {
+    let mut ast_mod = Module {
+        filename: "".to_string(),
+        pkg: "".to_string(),
+        doc: "".to_string(),
+        name: "".to_string(),
+        body: vec![],
+        comments: vec![],
+    };
+    let mut gen_schema_stmts = gen_schema_stmt(1);
+    ast_mod.body.append(&mut gen_schema_stmts);
+    let schema_stmts = ast_mod.filter_schema_stmt_from_module();
+    assert_eq!(schema_stmts.len(), 1);
+    assert_eq!(schema_stmts[0].node.name.node, "schema_stmt_0".to_string());
+}
+
+#[test]
+fn test_filter_schema_with_mult_schema() {
+    let mut ast_mod = Module {
+        filename: "".to_string(),
+        pkg: "".to_string(),
+        doc: "".to_string(),
+        name: "".to_string(),
+        body: vec![],
+        comments: vec![],
+    };
+    let mut gen_schema_stmts = gen_schema_stmt(10);
+    ast_mod.body.append(&mut gen_schema_stmts);
+    let schema_stmts = ast_mod.filter_schema_stmt_from_module();
+    assert_eq!(schema_stmts.len(), 10);
+    for i in 0..10 {
+        assert_eq!(
+            schema_stmts[i].node.name.node,
+            "schema_stmt_".to_string() + &i.to_string()
+        )
+    }
+}
+
+#[test]
+fn test_build_assign_stmt() {
+    let test_expr = node_ref!(ast::Expr::Identifier(Identifier {
+        names: vec!["name1".to_string(), "name2".to_string()],
+        pkgpath: "test".to_string(),
+        ctx: ast::ExprContext::Load
+    }));
+    let assgin_stmt = build_assign_node("test_attr_name", test_expr);
+
+    if let ast::Stmt::Assign(ref assign) = assgin_stmt.node {
+        if let ast::Expr::Identifier(ref iden) = &assign.value.node {
+            assert_eq!(iden.names.len(), 2);
+            assert_eq!(iden.names[0], "name1".to_string());
+            assert_eq!(iden.names[1], "name2".to_string());
+            assert_eq!(iden.pkgpath, "test".to_string());
+            match iden.ctx {
+                ast::ExprContext::Load => {}
+                _ => {
+                    assert!(false);
+                }
+            }
+        } else {
+            assert!(false);
+        }
+    } else {
+        assert!(false);
+    }
+}
+
+fn gen_schema_stmt(count: i32) -> Vec<NodeRef<ast::Stmt>> {
+    let mut schema_stmts = Vec::new();
+    for c in 0..count {
+        schema_stmts.push(node_ref!(ast::Stmt::Schema(SchemaStmt {
+            doc: "".to_string(),
+            name: node_ref!("schema_stmt_".to_string() + &c.to_string()),
+            parent_name: None,
+            for_host_name: None,
+            is_mixin: false,
+            is_protocol: false,
+            args: None,
+            mixins: vec![],
+            body: vec![],
+            decorators: vec![],
+            checks: vec![],
+            index_signature: None
+        })))
+    }
+    schema_stmts
 }

--- a/kclvm/compiler/Cargo.lock
+++ b/kclvm/compiler/Cargo.lock
@@ -424,6 +424,7 @@ dependencies = [
  "indexmap",
  "itertools",
  "json_minimal",
+ "kclvm-ast",
  "kclvm_runtime_internal_macros",
  "libc",
  "md5",

--- a/kclvm/config/Cargo.lock
+++ b/kclvm/config/Cargo.lock
@@ -243,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.6.6"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86018df177b1beef6c7c8ef949969c4f7cb9a9344181b92486b23c79995bdaa4"
+checksum = "1b861ecaade43ac97886a512b360d01d66be9f41f3c61088b42cedf92e03d678"
 dependencies = [
  "base64",
  "bitflags",

--- a/kclvm/parser/Cargo.lock
+++ b/kclvm/parser/Cargo.lock
@@ -485,6 +485,7 @@ dependencies = [
  "indexmap",
  "itertools",
  "json_minimal",
+ "kclvm-ast",
  "kclvm_runtime_internal_macros",
  "libc",
  "md5",
@@ -923,9 +924,9 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.6.6"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86018df177b1beef6c7c8ef949969c4f7cb9a9344181b92486b23c79995bdaa4"
+checksum = "1b861ecaade43ac97886a512b360d01d66be9f41f3c61088b42cedf92e03d678"
 dependencies = [
  "base64",
  "bitflags",

--- a/kclvm/parser/src/parser/expr.rs
+++ b/kclvm/parser/src/parser/expr.rs
@@ -8,8 +8,8 @@ use super::int::bytes_to_int;
 use super::Parser;
 
 use either::{self, Either};
+use kclvm_ast::node_ref;
 
-use crate::node_ref;
 use crate::parser::precedence::Precedence;
 use kclvm_ast::ast::*;
 use kclvm_ast::token;

--- a/kclvm/parser/src/parser/mod.rs
+++ b/kclvm/parser/src/parser/mod.rs
@@ -30,38 +30,6 @@ use kclvm_ast::token::{CommentKind, Token, TokenKind};
 use kclvm_ast::token_stream::{Cursor, TokenStream};
 use kclvm_span::symbol::Symbol;
 
-#[macro_export]
-macro_rules! node_ref {
-    ($node: expr) => {
-        NodeRef::new(Node::dummy_node($node))
-    };
-    ($node: expr, $pos:expr) => {
-        NodeRef::new(Node::node_with_pos($node, $pos))
-    };
-}
-
-#[macro_export]
-macro_rules! expr_as {
-    ($expr: expr, $expr_enum: path) => {
-        if let $expr_enum(x) = ($expr.node as Expr) {
-            Some(x)
-        } else {
-            None
-        }
-    };
-}
-
-#[macro_export]
-macro_rules! stmt_as {
-    ($stmt: expr, $stmt_enum: path) => {
-        if let $stmt_enum(x) = ($stmt.node as Stmt) {
-            Some(x)
-        } else {
-            None
-        }
-    };
-}
-
 pub struct Parser<'a> {
     /// The current token.
     pub token: Token,

--- a/kclvm/parser/src/parser/stmt.rs
+++ b/kclvm/parser/src/parser/stmt.rs
@@ -3,14 +3,12 @@
 
 use core::panic;
 
-use kclvm_ast::ast::*;
+use kclvm_ast::{ast::*, node_ref, expr_as};
 use kclvm_ast::token::{DelimToken, LitKind, Token, TokenKind};
 use kclvm_span::symbol::kw;
 
 use super::Parser;
 
-use crate::expr_as;
-use crate::node_ref;
 
 /// Parser implementation of statements, which consists of expressions and tokens.
 /// Parser uses `parse_exprlist` and `parse_expr` in [`kclvm_parser::parser::expr`]

--- a/kclvm/parser/src/parser/ty.rs
+++ b/kclvm/parser/src/parser/ty.rs
@@ -2,9 +2,7 @@
 
 use super::Parser;
 
-use crate::expr_as;
-
-use kclvm_ast::ast;
+use kclvm_ast::{ast, expr_as};
 use kclvm_ast::ast::{Expr, Node, NodeRef, Type};
 use kclvm_ast::token;
 use kclvm_ast::token::{BinOpToken, DelimToken, TokenKind};

--- a/kclvm/runner/Cargo.lock
+++ b/kclvm/runner/Cargo.lock
@@ -557,6 +557,7 @@ dependencies = [
  "indexmap",
  "itertools",
  "json_minimal",
+ "kclvm-ast",
  "kclvm_runtime_internal_macros",
  "libc",
  "md5",
@@ -1027,9 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.6.6"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86018df177b1beef6c7c8ef949969c4f7cb9a9344181b92486b23c79995bdaa4"
+checksum = "1b861ecaade43ac97886a512b360d01d66be9f41f3c61088b42cedf92e03d678"
 dependencies = [
  "base64",
  "bitflags",

--- a/kclvm/runtime/Cargo.lock
+++ b/kclvm/runtime/Cargo.lock
@@ -23,10 +23,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.0.1"
+name = "arrayvec"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
@@ -50,10 +56,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
  "generic-array",
 ]
@@ -68,6 +89,18 @@ dependencies = [
  "memchr",
  "regex-automata",
 ]
+
+[[package]]
+name = "cc"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -98,6 +131,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+dependencies = [
+ "cfg-if 1.0.0",
+ "lazy_static",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,10 +185,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer 0.10.2",
+ "crypto-common",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "ena"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7402b94a93c24e742487327a7cd839dc9d36fec9de9fb25b09f2dae459f36c3"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "fancy-regex"
@@ -120,6 +217,15 @@ checksum = "9d6b8560a05112eb52f04b00e5d3790c0dd75d9d980eb8a122fb23b92a623ccf"
 dependencies = [
  "bit-set",
  "regex",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -138,7 +244,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi",
 ]
@@ -150,13 +256,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
-name = "indexmap"
-version = "1.7.0"
+name = "hermit-abi"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
  "hashbrown",
+ "rustc-rayon",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -175,8 +300,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "json_minimal"
 version = "0.1.3"
+
+[[package]]
+name = "kclvm-ast"
+version = "0.1.0"
+dependencies = [
+ "kclvm-span",
+ "rustc_span",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "kclvm-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
 
 [[package]]
 name = "kclvm-runtime"
@@ -190,6 +344,7 @@ dependencies = [
  "indexmap",
  "itertools",
  "json_minimal",
+ "kclvm-ast",
  "kclvm_runtime_internal_macros",
  "libc",
  "md5",
@@ -199,10 +354,19 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha1",
- "sha2",
+ "sha2 0.9.8",
  "unic-ucd-bidi",
  "unic-ucd-category",
  "unicode-casing",
+]
+
+[[package]]
+name = "kclvm-span"
+version = "0.1.0"
+dependencies = [
+ "kclvm-macros",
+ "rustc_span",
+ "scoped-tls",
 ]
 
 [[package]]
@@ -233,10 +397,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
+name = "lock_api"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+
+[[package]]
+name = "md-5"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658646b21e0b72f7866c7038ab086d3d5e1cd6271f060fd37defb241949d0582"
+dependencies = [
+ "digest 0.10.3",
+]
 
 [[package]]
 name = "md5"
@@ -249,6 +441,24 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "memmap2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723e3ebdcdc5c023db1df315364573789f8857c11b631a2fdfad7c00f5c046b4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "num-integer"
@@ -270,6 +480,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,6 +500,29 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
+]
 
 [[package]]
 name = "phf"
@@ -326,6 +569,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +593,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "871372391786ccec00d3c5d3d6608905b3d4db263639cfe075d3b60a736d115a"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -396,6 +654,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,16 +686,117 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-rayon"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9974ab223660e61c1b4e7b43b827379df286736ca988308ce7e16f59f2d89246"
+dependencies = [
+ "crossbeam-deque",
+ "either",
+ "rustc-rayon-core",
+]
+
+[[package]]
+name = "rustc-rayon-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "564bfd27be8db888d0fa76aa4335e7851aaed0c2c11ad1e93aeb9349f6b88500"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
+name = "rustc_data_structures"
+version = "0.0.0"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "cfg-if 0.1.10",
+ "ena",
+ "indexmap",
+ "jobserver",
+ "libc",
+ "memmap2",
+ "parking_lot",
+ "rustc-hash",
+ "rustc-rayon",
+ "rustc-rayon-core",
+ "stable_deref_trait",
+ "stacker",
+ "tempfile",
+ "tracing",
+ "winapi",
+]
+
+[[package]]
+name = "rustc_span"
+version = "0.0.0"
+dependencies = [
+ "cfg-if 0.1.10",
+ "md-5",
+ "rustc_data_structures",
+ "scoped-tls",
+ "sha-1",
+ "sha2 0.10.2",
+ "tracing",
+ "unicode-width",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "serde"
 version = "1.0.131"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ad69dfbd3e45369132cc64e6748c2d65cdfb001a2b1c232d128b4ad60561c1"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.131"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b710a83c4e0dff6a3d511946b95274ad9ca9e5d3ae497b63fda866ac955358d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde_json"
@@ -454,6 +822,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.3",
+]
+
+[[package]]
 name = "sha1"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,11 +844,22 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
- "block-buffer",
- "cfg-if",
+ "block-buffer 0.9.0",
+ "cfg-if 1.0.0",
  "cpufeatures",
- "digest",
+ "digest 0.9.0",
  "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -477,6 +867,31 @@ name = "siphasher"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
+
+[[package]]
+name = "smallvec"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "stacker"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90939d5171a4420b3ff5fbc8954d641e7377335454c259dcb80786f3f21dc9b4"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "psm",
+ "winapi",
+]
 
 [[package]]
 name = "syn"
@@ -490,6 +905,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
 name = "time"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,6 +939,38 @@ dependencies = [
  "libc",
  "wasi",
  "winapi",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
+dependencies = [
+ "cfg-if 1.0.0",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -566,6 +1039,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "623f59e6af2a98bdafeb93fa277ac8e1e40440973001ca15cf4ae1541cd16d56"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,6 +1083,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "yaml-rust"

--- a/kclvm/runtime/Cargo.toml
+++ b/kclvm/runtime/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/lib.rs"
 
 [dependencies]
 kclvm_runtime_internal_macros = { path = "./internal_macros" }
+kclvm-ast = {path = "../ast", version = "0.1.0"}
 json_minimal = {path = "./src/3rdparty/json_minimal", version = "0.1.0"}
 serde_yaml = "0.8.23"
 

--- a/kclvm/runtime/src/value/val_fmt.rs
+++ b/kclvm/runtime/src/value/val_fmt.rs
@@ -5,6 +5,7 @@
 use itertools::{Itertools, PeekingNext};
 use std::cmp;
 use std::str::FromStr;
+use kclvm_ast::quoted_string;
 
 use crate::*;
 
@@ -974,19 +975,6 @@ pub fn value_to_quoted_string(value: &ValueRef) -> String {
         quoted_string(&value)
     } else {
         value.to_string()
-    }
-}
-
-/// Convert a Rust string to a quoted string e.g., abc -> 'abc'
-pub fn quoted_string(value: &str) -> String {
-    let has_double_quote = value.contains('\'');
-    let has_single_quote = value.contains('\"');
-    if !has_single_quote {
-        format!("'{}'", value)
-    } else if !has_double_quote {
-        format!("\"{}\"", value)
-    } else {
-        format!("\"{}\"", value.replace("\"", "\\\""))
     }
 }
 

--- a/kclvm/sema/Cargo.lock
+++ b/kclvm/sema/Cargo.lock
@@ -584,6 +584,7 @@ dependencies = [
  "indexmap",
  "itertools",
  "json_minimal",
+ "kclvm-ast",
  "kclvm_runtime_internal_macros",
  "libc",
  "md5",
@@ -1082,9 +1083,9 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.6.6"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86018df177b1beef6c7c8ef949969c4f7cb9a9344181b92486b23c79995bdaa4"
+checksum = "1b861ecaade43ac97886a512b360d01d66be9f41f3c61088b42cedf92e03d678"
 dependencies = [
  "base64",
  "bitflags",

--- a/kclvm/src/lib.rs
+++ b/kclvm/src/lib.rs
@@ -146,7 +146,8 @@ pub extern "C" fn kclvm_cli_run(args: *const i8, plugin_agent: *const i8) -> *co
                 std::fs::remove_file(&ll_path).unwrap();
             }
             ll_path_lock.unlock().unwrap();
-            tx.send(dylib_path).expect("channel will be there waiting for the pool");
+            tx.send(dylib_path)
+                .expect("channel will be there waiting for the pool");
         });
     }
     let dylib_paths = rx.iter().take(prog_count).collect::<Vec<String>>();

--- a/kclvm/src/main.rs
+++ b/kclvm/src/main.rs
@@ -18,7 +18,7 @@ use kclvm_runner::command::Command;
 use kclvm_sema::resolver::resolve_program;
 
 fn main() {
-    let matches = clap_app!(kclx =>
+    let matches = clap_app!(kcl =>
         (@subcommand run =>
             (@arg INPUT: ... "Sets the input file to use")
             (@arg OUTPUT: -o --output +takes_value "Sets the LLVM IR/BC output file path")

--- a/kclvm/tools/Cargo.lock
+++ b/kclvm/tools/Cargo.lock
@@ -493,6 +493,7 @@ dependencies = [
  "indexmap",
  "itertools",
  "json_minimal",
+ "kclvm-ast",
  "kclvm_runtime_internal_macros",
  "libc",
  "md5",


### PR DESCRIPTION
refactor: adjusted some macros in kclvm-parser and add some methods in kclvm-ast.
Note:
1. Adjusted the position of some macros in kclvm-parser.

What: 
1. Move some util macros for ast from kclvm-parser to kclvm-ast, 
   and add some new util methods in kclvm-ast.

How:
1. Move macros "node_ref", "expr_as" and "stmt_as" form from 
   kclvm-parser/mod.rs to kclvm-ast/lib.rs
2. Add method "build_assign_node" in kclvm-ast/lib.rs in order to 
   construct an AssignStmt
3. Add method "filter_schema_stmt_from_module" in kclvm-ast/ast.rs 
   in order to select all "SchemaStmt" in "Module".
4. Add method "TryFrom<...>" in kclvm-ast/ast.rs for "StringLit" and 
   "NameConstant" in order to convert from rust string and bool to 
   kclvm ast.

Why:
1. Adjust the structure of the kclvm-ast and add some util methods to 
   continuously enrich the infrastructure of KCLVM to support the 
   development.
