### PR TITLE
Dev/peefy/refactor sema code

### DIFF
--- a/kclvm/sema/src/pre_process/mod.rs
+++ b/kclvm/sema/src/pre_process/mod.rs
@@ -18,8 +18,9 @@ pub fn pre_process_program(program: &mut ast::Program) {
             if pkgpath != kclvm_ast::MAIN_PKG {
                 import_names.clear();
             }
-            fix_qualified_identifier(module, &mut import_names);
+            // First we should transform the raw identifier to avoid raw identifier that happens to be a package path.
             fix_raw_identifier_prefix(module);
+            fix_qualified_identifier(module, &mut import_names);
             fix_config_expr_nest_attr(module);
         }
     }

--- a/kclvm/sema/src/resolver/import.rs
+++ b/kclvm/sema/src/resolver/import.rs
@@ -26,6 +26,7 @@ impl<'ctx> Resolver<'ctx> {
                         if STANDARD_SYSTEM_MODULES.contains(&pkgpath.as_str()) {
                             continue;
                         }
+                        // Plugin module.
                         if pkgpath.starts_with(PLUGIN_MODULE_PREFIX) {
                             continue;
                         }
@@ -36,7 +37,7 @@ impl<'ctx> Resolver<'ctx> {
                                 ErrorKind::CannotFindModule,
                                 &[Message {
                                     pos: Position {
-                                        filename: self.ctx.filename.clone(),
+                                        filename: m.filename.clone(),
                                         line: stmt.line,
                                         column: Some(1),
                                     },
@@ -185,7 +186,21 @@ impl<'ctx> Resolver<'ctx> {
                     }
                 }
             }
-            None => bug!("pkgpath {} not found in the program", self.ctx.pkgpath),
+            None => {
+                self.handler.add_error(
+                    ErrorKind::CannotFindModule,
+                    &[Message {
+                        pos: Position {
+                            filename: self.ctx.filename.clone(),
+                            line: 1,
+                            column: Some(1),
+                        },
+                        style: Style::Line,
+                        message: format!("pkgpath {} not found in the program", self.ctx.pkgpath),
+                        note: None,
+                    }],
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Purpose:
1. add config entry recursive unify in the pre processs. The reason for modifying this is that the test found that no recursive merge was performed on the configured child nodes.
2. refine import pkgpath error emit. The reason for adjusting this is: this is not a bug, the `bug!()` function should not be called, but the error should be added to the `handler` for output.
3. move the raw identifier transformer call position. The reason for this adjustment is that the pkg name may be prefixed with `$`, so the `fix_raw_identifier_prefix` method needs to be called first.
4. bump to latest plugin submodule
