### PR TITLE
fix: string key node unify in the config.

### DIFF
--- a/kclvm/sema/src/pre_process/config.rs
+++ b/kclvm/sema/src/pre_process/config.rs
@@ -275,13 +275,11 @@ fn unify_config_entries(
     let mut bucket: IndexMap<String, Vec<ast::NodeRef<ast::ConfigEntry>>> = IndexMap::new();
     for entry in entries {
         let name = match &entry.node.key {
-            Some(key) => {
-                if let ast::Expr::Identifier(identifier) = &key.node {
-                    identifier.get_name()
-                } else {
-                    NAME_NONE_BUCKET_KEY.to_string()
-                }
-            }
+            Some(key) => match &key.node {
+                ast::Expr::Identifier(identifier) => identifier.get_name(),
+                ast::Expr::StringLit(string_lit) => string_lit.value.clone(),
+                _ => NAME_NONE_BUCKET_KEY.to_string(),
+            },
             None => NAME_NONE_BUCKET_KEY.to_string(),
         };
         let entry = entry.clone();

--- a/kclvm/sema/src/ty/mod.rs
+++ b/kclvm/sema/src/ty/mod.rs
@@ -152,13 +152,13 @@ pub struct SchemaType {
     /// The schema definition document string.
     pub doc: String,
     /// Indicates whether the schema is a type of a instance or
-    /// a type (value). Besides, it is necessary to distinguish 
+    /// a type (value). Besides, it is necessary to distinguish
     /// between a type instance and a type value, such as the following code:
     /// ```no_check
     /// # `Person` in `schema Person` is a type and it is not a schema instance.
     /// schema Person:
     ///     name: str
-    /// 
+    ///
     /// # `person` is a schema instance.
     /// person = Person {name = "Alice"}
     /// # `person` is a schema instance used in the value expression.


### PR DESCRIPTION
Purpose:

Why:
Compile-time configuration merging does not consider scenarios where identifier keys and string keys are the same, such as the following KCL code:

```kcl
schema Config:
     labels?: {str:str}

config: Config {
    labels.key1 = "value1"
   "labels": {
        "key2" = "value2"
   }
}
```
