### PR TITLE
refactor: modify error output.

### DIFF
--- a/kclvm/error/src/emitter.rs
+++ b/kclvm/error/src/emitter.rs
@@ -13,6 +13,7 @@ use termcolor::{BufferWriter, Color, ColorChoice, ColorSpec, StandardStream, Wri
 
 /// Emitter trait for emitting errors.
 pub trait Emitter {
+    fn format_diagnostic(&mut self, diag: &Diagnostic) -> Vec<String>;
     /// Emit a structured diagnostic.
     fn emit_diagnostic(&mut self, diag: &Diagnostic);
     /// Checks if we can use colors in the current output stream.
@@ -145,6 +146,14 @@ impl Emitter for EmitterWriter {
     }
 
     fn emit_diagnostic(&mut self, diag: &Diagnostic) {
+        let buffer = self.format_diagnostic(diag);
+        if let Err(e) = emit_to_destination(&buffer, &diag.level, &mut self.dst, self.short_message)
+        {
+            panic!("failed to emit error: {}", e)
+        }
+    }
+
+    fn format_diagnostic(&mut self, diag: &Diagnostic) -> Vec<String> {
         let mut buffer: Vec<String> = vec![];
         let mut diag_str = "KCL ".to_string();
         diag_str += diag.level.to_str();
@@ -192,10 +201,7 @@ impl Emitter for EmitterWriter {
             }
             buffer.push("".to_string());
         }
-        if let Err(e) = emit_to_destination(&buffer, &diag.level, &mut self.dst, self.short_message)
-        {
-            panic!("failed to emit error: {}", e)
-        }
+        buffer
     }
 }
 

--- a/kclvm/error/src/lib.rs
+++ b/kclvm/error/src/lib.rs
@@ -84,6 +84,14 @@ impl Handler {
         }
         self.has_errors()
     }
+    /// Format and return all diagnostics msg.
+    pub fn format_diagnostic(&mut self) -> Vec<String> {
+        let mut dia_msgs = Vec::new();
+        for diag in &self.diagnostics {
+            dia_msgs.append(&mut self.emitter.format_diagnostic(diag));
+        }
+        dia_msgs
+    }
 
     /// Emit all diagnostics and abort if has any errors.
     pub fn abort_if_errors(&mut self) -> ! {
@@ -104,7 +112,15 @@ impl Handler {
     /// Emit all diagnostics but do not abort.
     #[inline]
     pub fn alert_if_any_errors(&mut self) {
-        self.emit();
+        if self.has_errors() {
+            let mut err_msg = String::new();
+            let msgs = self.format_diagnostic();
+            for msg in msgs {
+                err_msg += &format!("{}\n", msg);
+            }
+
+            panic!("{}", err_msg)
+        }
     }
 
     /// Construct a parse error and put it into the handler diagnostic buffer

--- a/kclvm/sema/src/resolver/mod.rs
+++ b/kclvm/sema/src/resolver/mod.rs
@@ -92,7 +92,7 @@ impl<'ctx> Resolver<'ctx> {
         ProgramScope {
             scope_map: self.scope_map.clone(),
             import_names: self.ctx.import_names.clone(),
-            diagnostics: self.handler.diagnostics.clone()
+            diagnostics: self.handler.diagnostics.clone(),
         }
     }
 }
@@ -149,5 +149,6 @@ pub fn resolve_program(program: &mut Program) -> ProgramScope {
     let scope = resolver.check(kclvm_ast::MAIN_PKG);
     let type_alias_mapping = resolver.ctx.type_alias_mapping.clone();
     process_program_type_alias(program, type_alias_mapping);
+    scope.check_scope_diagnostics();
     scope
 }

--- a/kclvm/sema/src/resolver/scope.rs
+++ b/kclvm/sema/src/resolver/scope.rs
@@ -209,7 +209,7 @@ impl ProgramScope {
         self.scope_map.get(MAIN_PKG)
     }
 
-    pub fn check_scope_diagnostics(&self){
+    pub fn check_scope_diagnostics(&self) {
         if self.diagnostics.len() > 0 {
             let mut err_handler = Handler::default();
             err_handler.diagnostics = self.diagnostics.clone();

--- a/kclvm/sema/src/ty/mod.rs
+++ b/kclvm/sema/src/ty/mod.rs
@@ -152,13 +152,13 @@ pub struct SchemaType {
     /// The schema definition document string.
     pub doc: String,
     /// Indicates whether the schema is a type of a instance or
-    /// a type (value). Besides, it is necessary to distinguish 
+    /// a type (value). Besides, it is necessary to distinguish
     /// between a type instance and a type value, such as the following code:
     /// ```no_check
     /// # `Person` in `schema Person` is a type and it is not a schema instance.
     /// schema Person:
     ///     name: str
-    /// 
+    ///
     /// # `person` is a schema instance.
     /// person = Person {name = "Alice"}
     /// # `person` is a schema instance used in the value expression.

--- a/kclvm/src/lib.rs
+++ b/kclvm/src/lib.rs
@@ -28,7 +28,7 @@ pub extern "C" fn kclvm_cli_run(args: *const i8, plugin_agent: *const i8) -> *co
     let mut program = load_program(&files, Some(opts));
     apply_overrides(&mut program, &args.overrides, &[]);
     let scope = resolve_program(&mut program);
-
+    scope.check_scope_diagnostics();
     // gen bc or ll file
     let ll_file = "_a.out";
     let path = std::path::Path::new(ll_file);
@@ -163,7 +163,6 @@ pub extern "C" fn kclvm_cli_run(args: *const i8, plugin_agent: *const i8) -> *co
             plugin_agent_ptr: plugin_agent,
         }),
     );
-    scope.check_scope_diagnostics();
     match runner.run(&args) {
         Ok(result) => {
             let c_string = std::ffi::CString::new(result.as_str()).expect("CString::new failed");

--- a/kclvm/src/main.rs
+++ b/kclvm/src/main.rs
@@ -46,7 +46,7 @@ fn main() {
                 // load ast
                 let mut program = load_program(&files, None);
                 let scope = resolve_program(&mut program);
-
+                scope.check_scope_diagnostics();
                 // gen bc or ll file
                 let ll_file = "_a.out";
                 let path = std::path::Path::new(ll_file);
@@ -191,7 +191,6 @@ fn main() {
                         std::fs::remove_file(&dylib_path).unwrap();
                     }
                 }
-                scope.check_scope_diagnostics();
             }
         } else {
             println!("{}", matches.usage());


### PR DESCRIPTION
Note:
1. kclvm-error.alert_if_any_errors will panic.

What:
1. added panic in kclvm-error.alert_if_any_errors.

How:
1. added method “format_diagnostic” in “kclvm-error.Handler” to get the msg for panic.
2. added method "format_diagnostic" in trait "kclvm-error.Emitter" to get the msg for panic.

Why:
1. The error in resolver that needs to be thrown through panic.

- With pull requests:
  - Open your pull request against `main`
  - Your pull request should have no more than two commits, if not you should squash them.
  - It should pass all tests in the available continuous integration systems such as GitHub Actions.
  - You should add/modify tests to cover your proposed code changes.
  - If your pull request contains a new feature, please document it on the README.
