### PR TITLE
fix: ast printer on comment and lambda nodes because of the parser is…

### DIFF
--- a/kclvm/parser/src/parser/expr.rs
+++ b/kclvm/parser/src/parser/expr.rs
@@ -235,7 +235,7 @@ impl<'a> Parser<'a> {
                             // slice_suffix
                             operand = self.parse_subscript_expr(operand)
                         }
-                        _ => {}
+                        _ => break operand,
                     }
                 }
                 _ => break operand,

--- a/kclvm/tools/src/printer/mod.rs
+++ b/kclvm/tools/src/printer/mod.rs
@@ -214,8 +214,8 @@ impl<'p> Printer<'p> {
                 }
             }
             if let Some(index) = index {
-                let mut count = index;
-                while count > 0 {
+                let mut count = index as isize;
+                while count >= 0 {
                     match self.comments.pop_front() {
                         Some(comment) => {
                             self.writeln(&comment.node.text);
@@ -246,7 +246,7 @@ impl<'p> Printer<'p> {
 /// Print AST to string
 pub fn print_ast_module(module: &ast::Module) -> String {
     let mut printer = Printer::default();
-    printer.walk_module(module);
+    printer.write_module(module);
     printer.out
 }
 

--- a/kclvm/tools/src/printer/test_data/comment.output
+++ b/kclvm/tools/src/printer/test_data/comment.output
@@ -23,15 +23,9 @@ appConfiguration = AppConfiguration {
         disk: "50Gi"
         memory: "12Gi"
     }
-    labels: {
-        key: {
-            key: 12
-        }
-    }
+    labels: {key: {key: 12}}
     # Comment Six
-    mainContainer: Main {
-        name: "kusion_override"
-    }
+    mainContainer: Main {name: "kusion_override"}
     # Comment Seven
     # Comment Eight
     overQuota: True

--- a/kclvm/tools/src/printer/test_data/lambda.input
+++ b/kclvm/tools/src/printer/test_data/lambda.input
@@ -1,7 +1,6 @@
 sumFunc1 = lambda x, y {
     z = x + y
     z + x
-    
 }
 sumFunc2 = lambda x, y = 1 {
     x + y

--- a/kclvm/tools/src/printer/test_data/lambda.output
+++ b/kclvm/tools/src/printer/test_data/lambda.output
@@ -1,19 +1,19 @@
 sumFunc1 = lambda x, y {
     z = x + y
     z + x
-    
+
 }
 sumFunc2 = lambda x, y = 1 {
     x + y
-    
+
 }
 sumFunc3 = lambda x = 1, y = 1 {
     x + y
-    
+
 }
 sumFunc4 = lambda x: int = 1, y: int = 1 -> int {
     x + y
-    
+
 }
 x0 = sumFunc1(1, 2)
 x1 = sumFunc1(2, 3)

--- a/kclvm/tools/src/printer/tests.rs
+++ b/kclvm/tools/src/printer/tests.rs
@@ -4,15 +4,15 @@ use pretty_assertions::assert_eq;
 
 const FILE_INPUT_SUFFIX: &str = ".input";
 const FILE_OUTPUT_SUFFIX: &str = ".output";
-const TEST_CASES: &[&'static str; 10] = &[
+const TEST_CASES: &[&'static str; 12] = &[
     "arguments",
     "empty",
     "codelayout",
     "collection_if",
-    // "comment",
+    "comment",
     "index_sign",
     "joined_str",
-    // "lambda",
+    "lambda",
     "quant",
     "rule",
     "type_alias",


### PR DESCRIPTION
Purpose:
1. Restored AST printer lambda and comment test case due to previous parser lambda and comment bug.
