### PR TITLE
fix: the panic output information of "invalid binary operation" is formatted using PanicInfo.

### DIFF
--- a/kclvm/ast/src/ast.rs
+++ b/kclvm/ast/src/ast.rs
@@ -1132,6 +1132,26 @@ pub enum BinOp {
 }
 
 impl BinOp {
+    pub fn supported_bin_op() -> Vec<String> {
+        vec![
+            BinOp::Add.symbol().to_string(),
+            BinOp::Sub.symbol().to_string(),
+            BinOp::Mul.symbol().to_string(),
+            BinOp::Div.symbol().to_string(),
+            BinOp::Mod.symbol().to_string(),
+            BinOp::Pow.symbol().to_string(),
+            BinOp::FloorDiv.symbol().to_string(),
+            BinOp::LShift.symbol().to_string(),
+            BinOp::RShift.symbol().to_string(),
+            BinOp::BitXor.symbol().to_string(),
+            BinOp::BitAnd.symbol().to_string(),
+            BinOp::BitOr.symbol().to_string(),
+            BinOp::And.symbol().to_string(),
+            BinOp::Or.symbol().to_string(),
+            BinOp::As.symbol().to_string(),
+        ]
+    }
+
     pub fn symbol(&self) -> &'static str {
         match self {
             BinOp::Add => "+",
@@ -1278,6 +1298,22 @@ pub enum CmpOp {
 }
 
 impl CmpOp {
+    pub fn supported_cmp_op() -> Vec<String> {
+        vec![
+            CmpOp::Eq.symbol().to_string(),
+            CmpOp::NotEq.symbol().to_string(),
+            CmpOp::Lt.symbol().to_string(),
+            CmpOp::LtE.symbol().to_string(),
+            CmpOp::Gt.symbol().to_string(),
+            CmpOp::GtE.symbol().to_string(),
+            CmpOp::Is.symbol().to_string(),
+            CmpOp::In.symbol().to_string(),
+            CmpOp::NotIn.symbol().to_string(),
+            CmpOp::Not.symbol().to_string(),
+            CmpOp::IsNot.symbol().to_string(),
+        ]
+    }
+
     pub fn symbol(&self) -> &'static str {
         match self {
             CmpOp::Eq => "==",
@@ -1482,6 +1518,15 @@ impl TryFrom<token::Token> for UnaryOp {
                 }
             }
         }
+    }
+}
+
+impl BinOrCmpOp {
+    pub fn supported_op() -> Vec<String> {
+        let mut result = vec![];
+        result.append(&mut BinOp::supported_bin_op());
+        result.append(&mut CmpOp::supported_cmp_op());
+        result
     }
 }
 

--- a/kclvm/ast/src/ast.rs
+++ b/kclvm/ast/src/ast.rs
@@ -1132,7 +1132,7 @@ pub enum BinOp {
 }
 
 impl BinOp {
-    pub fn supported_bin_op() -> Vec<String> {
+    pub fn all_symbols() -> Vec<String> {
         vec![
             BinOp::Add.symbol().to_string(),
             BinOp::Sub.symbol().to_string(),
@@ -1298,7 +1298,7 @@ pub enum CmpOp {
 }
 
 impl CmpOp {
-    pub fn supported_cmp_op() -> Vec<String> {
+    pub fn all_symbols() -> Vec<String> {
         vec![
             CmpOp::Eq.symbol().to_string(),
             CmpOp::NotEq.symbol().to_string(),
@@ -1522,10 +1522,10 @@ impl TryFrom<token::Token> for UnaryOp {
 }
 
 impl BinOrCmpOp {
-    pub fn supported_op() -> Vec<String> {
+    pub fn all_symbols() -> Vec<String> {
         let mut result = vec![];
-        result.append(&mut BinOp::supported_bin_op());
-        result.append(&mut CmpOp::supported_cmp_op());
+        result.append(&mut BinOp::all_symbols());
+        result.append(&mut CmpOp::all_symbols());
         result
     }
 }

--- a/kclvm/parser/src/parser/expr.rs
+++ b/kclvm/parser/src/parser/expr.rs
@@ -133,7 +133,7 @@ impl<'a> Parser<'a> {
                     Ok(op) => op,
                     Err(()) => self
                         .sess
-                        .struct_token_error(&BinOrCmpOp::supported_op(), self.token),
+                        .struct_token_error(&BinOrCmpOp::all_symbols(), self.token),
                 }
             };
 

--- a/kclvm/parser/src/parser/expr.rs
+++ b/kclvm/parser/src/parser/expr.rs
@@ -128,8 +128,13 @@ impl<'a> Parser<'a> {
                     panic!("unreachable")
                 }
             } else {
-                BinOrCmpOp::try_from(self.token)
-                    .expect("invalid binary expr: missing binary operation")
+                let result = BinOrCmpOp::try_from(self.token);
+                match result {
+                    Ok(op) => op,
+                    Err(()) => self
+                        .sess
+                        .struct_token_error(&BinOrCmpOp::supported_op(), self.token),
+                }
             };
 
             self.bump();
@@ -187,11 +192,10 @@ impl<'a> Parser<'a> {
                     self.sess.struct_token_loc(token, self.prev_token),
                 ))
             } else {
-                self.sess
-                    .struct_token_error(&[&kw::Else.into()], self.token)
+                self.sess.struct_token_error(&[kw::Else.into()], self.token)
             }
         } else {
-            self.sess.struct_token_error(&[&kw::If.into()], self.token)
+            self.sess.struct_token_error(&[kw::If.into()], self.token)
         }
     }
 
@@ -303,7 +307,7 @@ impl<'a> Parser<'a> {
         match self.token.kind {
             TokenKind::OpenDelim(DelimToken::Paren) => self.bump(),
             _ => self.sess.struct_token_error(
-                &[&TokenKind::OpenDelim(DelimToken::Paren).into()],
+                &[TokenKind::OpenDelim(DelimToken::Paren).into()],
                 self.token,
             ),
         }
@@ -324,7 +328,7 @@ impl<'a> Parser<'a> {
         match self.token.kind {
             TokenKind::CloseDelim(DelimToken::Paren) => self.bump(),
             _ => self.sess.struct_token_error(
-                &[&TokenKind::CloseDelim(DelimToken::Paren).into()],
+                &[TokenKind::CloseDelim(DelimToken::Paren).into()],
                 self.token,
             ),
         }
@@ -351,7 +355,7 @@ impl<'a> Parser<'a> {
         match self.token.kind {
             TokenKind::OpenDelim(DelimToken::Bracket) => self.bump(),
             _ => self.sess.struct_token_error(
-                &[&TokenKind::OpenDelim(DelimToken::Bracket).into()],
+                &[TokenKind::OpenDelim(DelimToken::Bracket).into()],
                 self.token,
             ),
         }
@@ -373,7 +377,7 @@ impl<'a> Parser<'a> {
 
                     if colon_counter > 2 {
                         self.sess
-                            .struct_token_error(&[&"expression".to_string()], self.token)
+                            .struct_token_error(&["expression".to_string()], self.token)
                     }
                     exprs_consecutive -= 1
                 }
@@ -405,7 +409,7 @@ impl<'a> Parser<'a> {
         match self.token.kind {
             TokenKind::CloseDelim(DelimToken::Bracket) => self.bump(),
             _ => self.sess.struct_token_error(
-                &[&TokenKind::CloseDelim(DelimToken::Bracket).into()],
+                &[TokenKind::CloseDelim(DelimToken::Bracket).into()],
                 self.token,
             ),
         }
@@ -514,9 +518,9 @@ impl<'a> Parser<'a> {
                     // Note: None and Undefined are handled in ident, skip handle them here.
                     _ => self.sess.struct_token_error(
                         &[
-                            &token::LitKind::Bool.into(),
-                            &token::LitKind::Integer.into(),
-                            &token::LitKind::Str {
+                            token::LitKind::Bool.into(),
+                            token::LitKind::Integer.into(),
+                            token::LitKind::Str {
                                 is_long_string: false,
                                 is_raw: false,
                             }
@@ -537,9 +541,9 @@ impl<'a> Parser<'a> {
                     DelimToken::Brace => self.parse_config_expr(),
                     _ => self.sess.struct_token_error(
                         &[
-                            &TokenKind::OpenDelim(DelimToken::Paren).into(),
-                            &TokenKind::OpenDelim(DelimToken::Bracket).into(),
-                            &TokenKind::OpenDelim(DelimToken::Brace).into(),
+                            TokenKind::OpenDelim(DelimToken::Paren).into(),
+                            TokenKind::OpenDelim(DelimToken::Bracket).into(),
+                            TokenKind::OpenDelim(DelimToken::Brace).into(),
                         ],
                         self.token,
                     ),
@@ -547,9 +551,9 @@ impl<'a> Parser<'a> {
             }
             _ => self.sess.struct_token_error(
                 &[
-                    &TokenKind::ident_value(),
-                    &TokenKind::literal_value(),
-                    &TokenKind::OpenDelim(DelimToken::NoDelim).into(),
+                    TokenKind::ident_value(),
+                    TokenKind::literal_value(),
+                    TokenKind::OpenDelim(DelimToken::NoDelim).into(),
                 ],
                 self.token,
             ),
@@ -582,10 +586,10 @@ impl<'a> Parser<'a> {
         } else {
             self.sess.struct_token_error(
                 &[
-                    &QuantOperation::All.into(),
-                    &QuantOperation::Any.into(),
-                    &QuantOperation::Filter.into(),
-                    &QuantOperation::Map.into(),
+                    QuantOperation::All.into(),
+                    QuantOperation::Any.into(),
+                    QuantOperation::Filter.into(),
+                    QuantOperation::Map.into(),
                 ],
                 self.token,
             )
@@ -603,7 +607,7 @@ impl<'a> Parser<'a> {
         if self.token.is_keyword(kw::In) {
             self.bump();
         } else {
-            self.sess.struct_token_error(&[&kw::In.into()], self.token)
+            self.sess.struct_token_error(&[kw::In.into()], self.token)
         }
 
         // quant_target
@@ -615,7 +619,7 @@ impl<'a> Parser<'a> {
                 self.bump();
             }
             _ => self.sess.struct_token_error(
-                &[&TokenKind::OpenDelim(DelimToken::Brace).into()],
+                &[TokenKind::OpenDelim(DelimToken::Brace).into()],
                 self.token,
             ),
         }
@@ -628,7 +632,7 @@ impl<'a> Parser<'a> {
                 self.bump();
             } else {
                 self.sess
-                    .struct_token_error(&[&TokenKind::Indent.into()], self.token)
+                    .struct_token_error(&[TokenKind::Indent.into()], self.token)
             }
 
             true
@@ -654,14 +658,14 @@ impl<'a> Parser<'a> {
                 self.skip_newlines();
             } else {
                 self.sess
-                    .struct_token_error(&[&TokenKind::Newline.into()], self.token)
+                    .struct_token_error(&[TokenKind::Newline.into()], self.token)
             }
 
             if self.token.kind == TokenKind::Dedent {
                 self.bump();
             } else {
                 self.sess
-                    .struct_token_error(&[&TokenKind::Dedent.into()], self.token)
+                    .struct_token_error(&[TokenKind::Dedent.into()], self.token)
             }
         }
 
@@ -671,7 +675,7 @@ impl<'a> Parser<'a> {
                 self.bump();
             }
             _ => self.sess.struct_token_error(
-                &[&TokenKind::CloseDelim(DelimToken::Brace).into()],
+                &[TokenKind::CloseDelim(DelimToken::Brace).into()],
                 self.token,
             ),
         }
@@ -705,13 +709,13 @@ impl<'a> Parser<'a> {
                 {
                     self.sess.struct_token_error(
                         &[
-                            &kw::None.into(),
-                            &kw::Undefined.into(),
-                            &kw::Lambda.into(),
-                            &kw::Any.into(),
-                            &kw::All.into(),
-                            &kw::Map.into(),
-                            &kw::Filter.into(),
+                            kw::None.into(),
+                            kw::Undefined.into(),
+                            kw::Lambda.into(),
+                            kw::Any.into(),
+                            kw::All.into(),
+                            kw::Map.into(),
+                            kw::Filter.into(),
                         ],
                         self.token,
                     )
@@ -726,7 +730,7 @@ impl<'a> Parser<'a> {
                     token::LitKind::Str { .. } => self.parse_str_expr(lk),
                     // Note: None and Undefined are handled in ident, skip handle them here.
                     _ => self.sess.struct_token_error(
-                        &[&token::LitKind::Str {
+                        &[token::LitKind::Str {
                             is_long_string: false,
                             is_raw: false,
                         }
@@ -744,8 +748,8 @@ impl<'a> Parser<'a> {
                     DelimToken::Brace => self.parse_config_expr(),
                     _ => self.sess.struct_token_error(
                         &[
-                            &TokenKind::OpenDelim(DelimToken::Bracket).into(),
-                            &TokenKind::OpenDelim(DelimToken::Brace).into(),
+                            TokenKind::OpenDelim(DelimToken::Bracket).into(),
+                            TokenKind::OpenDelim(DelimToken::Brace).into(),
                         ],
                         self.token,
                     ),
@@ -753,9 +757,9 @@ impl<'a> Parser<'a> {
             }
             _ => self.sess.struct_token_error(
                 &[
-                    &TokenKind::ident_value(),
-                    &TokenKind::literal_value(),
-                    &TokenKind::OpenDelim(DelimToken::NoDelim).into(),
+                    TokenKind::ident_value(),
+                    TokenKind::literal_value(),
+                    TokenKind::OpenDelim(DelimToken::NoDelim).into(),
                 ],
                 self.token,
             ),
@@ -798,7 +802,7 @@ impl<'a> Parser<'a> {
                 ));
             } else {
                 self.sess
-                    .struct_token_error(&[&TokenKind::Indent.into()], self.token)
+                    .struct_token_error(&[TokenKind::Indent.into()], self.token)
             }
             true
         } else {
@@ -815,7 +819,7 @@ impl<'a> Parser<'a> {
                 self.bump();
             } else {
                 self.sess
-                    .struct_token_error(&[&TokenKind::Dedent.into()], self.token)
+                    .struct_token_error(&[TokenKind::Dedent.into()], self.token)
             }
         }
 
@@ -825,7 +829,7 @@ impl<'a> Parser<'a> {
                 self.bump();
             }
             _ => self.sess.struct_token_error(
-                &[&TokenKind::CloseDelim(DelimToken::Bracket).into()],
+                &[TokenKind::CloseDelim(DelimToken::Bracket).into()],
                 self.token,
             ),
         }
@@ -1100,7 +1104,7 @@ impl<'a> Parser<'a> {
                 ));
             } else {
                 self.sess
-                    .struct_token_error(&[&TokenKind::Indent.into()], self.token)
+                    .struct_token_error(&[TokenKind::Indent.into()], self.token)
             }
             true
         } else {
@@ -1117,7 +1121,7 @@ impl<'a> Parser<'a> {
                 self.bump();
             } else {
                 self.sess
-                    .struct_token_error(&[&TokenKind::Dedent.into()], self.token)
+                    .struct_token_error(&[TokenKind::Dedent.into()], self.token)
             }
         }
 
@@ -1127,7 +1131,7 @@ impl<'a> Parser<'a> {
                 self.bump();
             }
             _ => self.sess.struct_token_error(
-                &[&TokenKind::CloseDelim(DelimToken::Brace).into()],
+                &[TokenKind::CloseDelim(DelimToken::Brace).into()],
                 self.token,
             ),
         }
@@ -1224,9 +1228,9 @@ impl<'a> Parser<'a> {
                         }
                         _ => self.sess.struct_token_error(
                             &[
-                                &TokenKind::Colon.into(),
-                                &TokenKind::Assign.into(),
-                                &TokenKind::BinOpEq(BinOpToken::Plus).into(),
+                                TokenKind::Colon.into(),
+                                TokenKind::Assign.into(),
+                                TokenKind::BinOpEq(BinOpToken::Plus).into(),
                             ],
                             self.token,
                         ),
@@ -1286,7 +1290,7 @@ impl<'a> Parser<'a> {
         }
 
         if !self.token.is_keyword(kw::In) {
-            self.sess.struct_token_error(&[&kw::In.into()], self.token)
+            self.sess.struct_token_error(&[kw::In.into()], self.token)
         }
         self.bump();
 
@@ -1628,7 +1632,7 @@ impl<'a> Parser<'a> {
             Ok(v) => v,
             Err(_) => self
                 .sess
-                .struct_token_error(&[&TokenKind::ident_value()], self.token),
+                .struct_token_error(&[TokenKind::ident_value()], self.token),
         };
 
         // config_expr
@@ -1653,7 +1657,7 @@ impl<'a> Parser<'a> {
             Ok(v) => v,
             Err(_) => self
                 .sess
-                .struct_token_error(&[&TokenKind::ident_value()], self.token),
+                .struct_token_error(&[TokenKind::ident_value()], self.token),
         };
 
         // config_expr
@@ -1711,7 +1715,7 @@ impl<'a> Parser<'a> {
                 self.bump();
             } else {
                 self.sess
-                    .struct_token_error(&[&TokenKind::Indent.into()], self.token)
+                    .struct_token_error(&[TokenKind::Indent.into()], self.token)
             }
             true
         } else {
@@ -1737,7 +1741,7 @@ impl<'a> Parser<'a> {
                 self.bump();
             } else {
                 self.sess
-                    .struct_token_error(&[&TokenKind::Dedent.into()], self.token)
+                    .struct_token_error(&[TokenKind::Dedent.into()], self.token)
             }
         }
 
@@ -1776,8 +1780,7 @@ impl<'a> Parser<'a> {
 
             s.to_string()
         } else {
-            self.sess
-                .struct_token_error(&[&kw::Type.into()], self.token)
+            self.sess.struct_token_error(&[kw::Type.into()], self.token)
         }
     }
 
@@ -1793,7 +1796,7 @@ impl<'a> Parser<'a> {
                 self.bump();
             }
             _ => self.sess.struct_token_error(
-                &[&token::TokenKind::CloseDelim(token::DelimToken::Paren).into()],
+                &[token::TokenKind::CloseDelim(token::DelimToken::Paren).into()],
                 self.token,
             ),
         }
@@ -1856,7 +1859,7 @@ impl<'a> Parser<'a> {
                     Expr::Identifier(x) => x.clone(),
                     _ => self
                         .sess
-                        .struct_token_error(&[&TokenKind::ident_value()], self.token),
+                        .struct_token_error(&[TokenKind::ident_value()], self.token),
                 };
 
                 // expr
@@ -1943,7 +1946,7 @@ impl<'a> Parser<'a> {
             }
             None => self
                 .sess
-                .struct_token_error(&[&TokenKind::ident_value()], self.token),
+                .struct_token_error(&[TokenKind::ident_value()], self.token),
         }
 
         loop {
@@ -1959,7 +1962,7 @@ impl<'a> Parser<'a> {
                         }
                         None => self
                             .sess
-                            .struct_token_error(&[&TokenKind::ident_value()], self.token),
+                            .struct_token_error(&[TokenKind::ident_value()], self.token),
                     }
                 }
                 _ => break,
@@ -1997,10 +2000,7 @@ impl<'a> Parser<'a> {
                 (None, NumberLitValue::Float(value))
             }
             _ => self.sess.struct_token_error(
-                &[
-                    &token::LitKind::Integer.into(),
-                    &token::LitKind::Float.into(),
-                ],
+                &[token::LitKind::Integer.into(), token::LitKind::Float.into()],
                 self.token,
             ),
         };
@@ -2030,7 +2030,7 @@ impl<'a> Parser<'a> {
                 (is_long_string, raw_value, value)
             }
             _ => self.sess.struct_token_error(
-                &[&token::LitKind::Str {
+                &[token::LitKind::Str {
                     is_long_string: false,
                     is_raw: false,
                 }
@@ -2071,16 +2071,16 @@ impl<'a> Parser<'a> {
                     NameConstant::False
                 } else {
                     self.sess
-                        .struct_token_error(&[&token::LitKind::Bool.into()], self.token)
+                        .struct_token_error(&[token::LitKind::Bool.into()], self.token)
                 }
             }
             token::LitKind::None => NameConstant::None,
             token::LitKind::Undefined => NameConstant::Undefined,
             _ => self.sess.struct_token_error(
                 &[
-                    &token::LitKind::Bool.into(),
-                    &token::LitKind::None.into(),
-                    &token::LitKind::Undefined.into(),
+                    token::LitKind::Bool.into(),
+                    token::LitKind::None.into(),
+                    token::LitKind::Undefined.into(),
                 ],
                 self.token,
             ),

--- a/kclvm/parser/src/parser/stmt.rs
+++ b/kclvm/parser/src/parser/stmt.rs
@@ -987,7 +987,7 @@ impl<'a> Parser<'_> {
                 self.bump();
             } else {
                 self.sess
-                    .struct_token_error(&[&TokenKind::Indent.into()], self.token)
+                    .struct_token_error(&[TokenKind::Indent.into()], self.token)
             }
             true
         } else {
@@ -1019,7 +1019,7 @@ impl<'a> Parser<'_> {
                 self.bump();
             } else {
                 self.sess
-                    .struct_token_error(&[&TokenKind::Dedent.into()], self.token)
+                    .struct_token_error(&[TokenKind::Dedent.into()], self.token)
             }
         }
 

--- a/kclvm/parser/src/session/mod.rs
+++ b/kclvm/parser/src/session/mod.rs
@@ -28,10 +28,10 @@ impl ParseSession {
     }
 
     /// Struct and report an error based on a token and abort the compiler process.
-    pub fn struct_token_error(&self, expected: &[&String], got: Token) -> ! {
+    pub fn struct_token_error(&self, expected: &[String], got: Token) -> ! {
         let pos: Position = self.source_map.lookup_char_pos(got.span.lo()).into();
         let err = ParseError::UnexpectedToken {
-            expected: expected.iter().map(|tok| (*tok).into()).collect(),
+            expected: expected.iter().map(|tok| tok.into()).collect(),
             got: got.into(),
         };
 

--- a/kclvm/parser/src/tests.rs
+++ b/kclvm/parser/src/tests.rs
@@ -1,3 +1,5 @@
+use std::panic::catch_unwind;
+
 use crate::*;
 
 use expect_test::{expect, Expect};
@@ -71,4 +73,21 @@ c = 3 # comment4444
         {"filename":"hello.k","pkg":"__main__","doc":"","name":"__main__","body":[{"node":{"Assign":{"targets":[{"node":{"names":["a"],"pkgpath":"","ctx":"Store"},"filename":"hello.k","line":3,"column":0,"end_line":3,"end_column":1}],"value":{"node":{"NumberLit":{"binary_suffix":null,"value":{"Int":1}}},"filename":"hello.k","line":3,"column":4,"end_line":3,"end_column":5},"type_annotation":null}},"filename":"hello.k","line":3,"column":0,"end_line":5,"end_column":0},{"node":{"Assign":{"targets":[{"node":{"names":["b"],"pkgpath":"","ctx":"Store"},"filename":"hello.k","line":5,"column":0,"end_line":5,"end_column":1}],"value":{"node":{"NumberLit":{"binary_suffix":null,"value":{"Int":2}}},"filename":"hello.k","line":5,"column":4,"end_line":5,"end_column":5},"type_annotation":null}},"filename":"hello.k","line":5,"column":0,"end_line":7,"end_column":0},{"node":{"Assign":{"targets":[{"node":{"names":["c"],"pkgpath":"","ctx":"Store"},"filename":"hello.k","line":7,"column":0,"end_line":7,"end_column":1}],"value":{"node":{"NumberLit":{"binary_suffix":null,"value":{"Int":3}}},"filename":"hello.k","line":7,"column":4,"end_line":7,"end_column":5},"type_annotation":null}},"filename":"hello.k","line":7,"column":0,"end_line":8,"end_column":0}],"comments":[{"node":{"text":"# comment1"},"filename":"hello.k","line":2,"column":0,"end_line":2,"end_column":10},{"node":{"text":"# comment22"},"filename":"hello.k","line":4,"column":0,"end_line":4,"end_column":11},{"node":{"text":"# comment333"},"filename":"hello.k","line":6,"column":0,"end_line":6,"end_column":12},{"node":{"text":"# comment4444"},"filename":"hello.k","line":7,"column":6,"end_line":7,"end_column":19}]}
         "###]],
     );
+}
+
+#[test]
+pub fn test_parse_expr_invalid_binary_expr() {
+    let result = catch_unwind(|| {
+        parse_expr("fs1_i1re1~s");
+    });
+    match result {
+        Err(e) => match e.downcast::<String>() {
+            Ok(_v) => {
+                let got = _v.to_string();
+                let _u: PanicInfo = serde_json::from_str(&got).unwrap();
+            }
+            _ => unreachable!(),
+        },
+        _ => {}
+    };
 }


### PR DESCRIPTION
fix: the panic output information of "invalid binary operation" is formatted using PanicInfo.

1. call the method "struct_token_error" in "do_parse_simple_expr" to format the panic message.
2. add method "supported_xx()" in ast.BinOp, ast.CmpOp and ast.BinOrCmpOp for easy access to the supported operations list.
3. adjusted the parameter type of method "struct_token_error" to fit the return value of method "supported_xx()".
4. add test case.

- With pull requests:
  - Open your pull request against `main`
  - Your pull request should have no more than two commits, if not you should squash them.
  - It should pass all tests in the available continuous integration systems such as GitHub Actions.
  - You should add/modify tests to cover your proposed code changes.
  - If your pull request contains a new feature, please document it on the README.
