### PR TITLE
fix: fix an array out of bounds issue in parser/src/lexer/lex_token()

### DIFF
--- a/kclvm/parser/src/lexer/mod.rs
+++ b/kclvm/parser/src/lexer/mod.rs
@@ -240,13 +240,19 @@ impl<'a> Lexer<'a> {
             // Binary op
             kclvm_lexer::TokenKind::Plus => token::BinOp(token::Plus),
             kclvm_lexer::TokenKind::Minus => {
-                let next_tkn =
-                    self.str_from_to(start + BytePos::from_u32(1), start + BytePos::from_u32(2));
-                if next_tkn == ">" {
-                    // waste '>' token
-                    self.pos = self.pos + BytePos::from_usize(1);
-                    token::RArrow
-                } else {
+                let head = start + BytePos::from_u32(1);
+                let tail = start + BytePos::from_u32(2);
+                if self.has_next_token(head, tail){
+                    let next_tkn =
+                        self.str_from_to(head, tail);
+                    if next_tkn == ">" {
+                        // waste '>' token
+                        self.pos = self.pos + BytePos::from_usize(1);
+                        token::RArrow
+                    } else {
+                        token::BinOp(token::Minus) 
+                    }
+                }else{
                     token::BinOp(token::Minus)
                 }
             }
@@ -538,6 +544,10 @@ impl<'a> Lexer<'a> {
     /// Slice of the source text spanning from `start` up to but excluding `end`.
     fn str_from_to(&self, start: BytePos, end: BytePos) -> &str {
         &self.src[self.src_index(start)..self.src_index(end)]
+    }
+
+    fn has_next_token(&self, start: BytePos, end: BytePos) -> bool{
+        if self.src_index(start) > self.src_index(end) || self.src_index(end) > self.src.len(){ false }else{ true }
     }
 
     fn symbol_from_to(&self, start: BytePos, end: BytePos) -> Symbol {

--- a/kclvm/parser/src/tests.rs
+++ b/kclvm/parser/src/tests.rs
@@ -1,3 +1,5 @@
+use std::panic::catch_unwind;
+
 use crate::*;
 
 use expect_test::{expect, Expect};
@@ -71,4 +73,21 @@ c = 3 # comment4444
         {"filename":"hello.k","pkg":"__main__","doc":"","name":"__main__","body":[{"node":{"Assign":{"targets":[{"node":{"names":["a"],"pkgpath":"","ctx":"Store"},"filename":"hello.k","line":3,"column":0,"end_line":3,"end_column":1}],"value":{"node":{"NumberLit":{"binary_suffix":null,"value":{"Int":1}}},"filename":"hello.k","line":3,"column":4,"end_line":3,"end_column":5},"type_annotation":null}},"filename":"hello.k","line":3,"column":0,"end_line":5,"end_column":0},{"node":{"Assign":{"targets":[{"node":{"names":["b"],"pkgpath":"","ctx":"Store"},"filename":"hello.k","line":5,"column":0,"end_line":5,"end_column":1}],"value":{"node":{"NumberLit":{"binary_suffix":null,"value":{"Int":2}}},"filename":"hello.k","line":5,"column":4,"end_line":5,"end_column":5},"type_annotation":null}},"filename":"hello.k","line":5,"column":0,"end_line":7,"end_column":0},{"node":{"Assign":{"targets":[{"node":{"names":["c"],"pkgpath":"","ctx":"Store"},"filename":"hello.k","line":7,"column":0,"end_line":7,"end_column":1}],"value":{"node":{"NumberLit":{"binary_suffix":null,"value":{"Int":3}}},"filename":"hello.k","line":7,"column":4,"end_line":7,"end_column":5},"type_annotation":null}},"filename":"hello.k","line":7,"column":0,"end_line":8,"end_column":0}],"comments":[{"node":{"text":"# comment1"},"filename":"hello.k","line":2,"column":0,"end_line":2,"end_column":10},{"node":{"text":"# comment22"},"filename":"hello.k","line":4,"column":0,"end_line":4,"end_column":11},{"node":{"text":"# comment333"},"filename":"hello.k","line":6,"column":0,"end_line":6,"end_column":12},{"node":{"text":"# comment4444"},"filename":"hello.k","line":7,"column":6,"end_line":7,"end_column":19}]}
         "###]],
     );
+}
+
+#[test]
+pub fn test_parse_expr_invalid_arr_out_of_bound_for_token_minus(){
+    let result = catch_unwind(|| {
+        parse_expr("fh==-h==-");
+    });
+    match result {
+        Err(e) => match e.downcast::<String>() {
+            Ok(_v) => {
+                let got = _v.to_string();
+                let _u: PanicInfo = serde_json::from_str(&got).unwrap();
+            }
+            _ => unreachable!(),
+        },
+        _ => {}
+    };
 }


### PR DESCRIPTION
fix: fix an array out of bounds issue in parser/src/lexer/lex_token()
1. add method ”has_next_token()“ in parser/src/lexer/Lexer to to check 
   if an array is out of bounds.
