### PR TITLE
refactor: modify main pkg front import.

### DIFF
--- a/kclvm/sema/src/pre_process/mod.rs
+++ b/kclvm/sema/src/pre_process/mod.rs
@@ -14,6 +14,15 @@ pub use identifier::{fix_qualified_identifier, fix_raw_identifier_prefix};
 pub fn pre_process_program(program: &mut ast::Program) {
     for (pkgpath, modules) in program.pkgs.iter_mut() {
         let mut import_names = IndexMap::default();
+        if pkgpath == kclvm_ast::MAIN_PKG {
+            for module in modules.iter_mut() {
+                for stmt in &module.body {
+                    if let ast::Stmt::Import(import_stmt) = &stmt.node {
+                        import_names.insert(import_stmt.name.clone(), import_stmt.path.clone());
+                    }
+                }
+            }
+        }
         for module in modules.iter_mut() {
             if pkgpath != kclvm_ast::MAIN_PKG {
                 import_names.clear();

--- a/kclvm/sema/src/pre_process/tests.rs
+++ b/kclvm/sema/src/pre_process/tests.rs
@@ -4,7 +4,8 @@ use kclvm_parser::parse_file;
 
 #[test]
 fn test_fix_qualified_identifier() {
-    let mut module = parse_file("./src/pre_process/test_data/qualified_identifier.k", None).unwrap();
+    let mut module =
+        parse_file("./src/pre_process/test_data/qualified_identifier.k", None).unwrap();
     fix_qualified_identifier(&mut module, &mut IndexMap::default());
     if let ast::Stmt::Assign(assign_stmt) = &module.body[1].node {
         if let ast::Expr::Identifier(identifier) = &assign_stmt.value.node {


### PR DESCRIPTION
Purpose:
1. refactor main pkg import lookup rules
