### PR TITLE
fix: the panic output information of "invalid number" is formatted using PanicInfo.

### DIFF
--- a/kclvm/parser/src/parser/expr.rs
+++ b/kclvm/parser/src/parser/expr.rs
@@ -1988,15 +1988,26 @@ impl<'a> Parser<'a> {
 
         let (binary_suffix, value) = match lk.kind {
             token::LitKind::Integer => {
-                let value = bytes_to_int(lk.symbol.as_str().as_bytes(), 0).unwrap();
-
+                let result = bytes_to_int(lk.symbol.as_str().as_bytes(), 0);
+                let value = match result {
+                    Some(value) => value,
+                    None => {
+                        self.sess.struct_token_error(&[token::LitKind::Integer.into()], token);
+                    }
+                };
                 match lk.suffix {
                     Some(suffix) => (suffix.as_str().try_into().ok(), NumberLitValue::Int(value)),
                     None => (None, NumberLitValue::Int(value)),
                 }
             }
             token::LitKind::Float => {
-                let value = lk.symbol.as_str().parse().unwrap();
+                let result = lk.symbol.as_str().parse();
+                let value = match result {
+                    Ok(value) => value,
+                    _ => {
+                        self.sess.struct_token_error(&[token::LitKind::Float.into()], token);
+                    }
+                };
                 (None, NumberLitValue::Float(value))
             }
             _ => self.sess.struct_token_error(

--- a/kclvm/parser/src/tests.rs
+++ b/kclvm/parser/src/tests.rs
@@ -91,3 +91,22 @@ pub fn test_parse_expr_invalid_binary_expr() {
         _ => {}
     };
 }
+
+
+#[test]
+pub fn test_parse_expr_invalid_binary_expr1(){
+    let result = catch_unwind(|| {
+        parse_expr("8_________i");
+    });
+    match result {
+        Err(e) => match e.downcast::<String>() {
+            Ok(_v) => {
+                let got = _v.to_string();
+                let _u: PanicInfo = serde_json::from_str(&got).unwrap();
+                println!("{}", _u.message);
+            }
+            _ => unreachable!(),
+        },
+        _ => {}
+    };
+}


### PR DESCRIPTION
#### What is the scope of this change (e.g. component or file name):
1. kclvm/parser/src/test.rs, 
2. kclvm/parser/src/parser/expr.rs

#### Provide a description of the change(e.g. more details, motivations or doc link):
1. call the method "struct_token_error" in "parse_num_expr" to format the panic message.
2. add and refactor the test case, merged "test_parse_expr_invalid_binary_expr" and "test_parse_expr_invalid_arr_out_of_bound_for_token_minus" into "test_parse_expr_invalid".

#### Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):
- N

#### Does this change affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):
- Y, https://github.com/KusionStack/KCLVM/issues/44
