### PR TITLE
fix(kclvm-parser): bug fix for unicode error

### DIFF
--- a/kclvm/error/src/lib.rs
+++ b/kclvm/error/src/lib.rs
@@ -162,6 +162,16 @@ impl Handler {
                 );
                 self.add_diagnostic(diag);
             }
+            ParseError::UnicodeError => {
+                let message = "Illegal Unicode";
+                let diag = Diagnostic::new_with_code(
+                    Level::Error,
+                    &message,
+                    pos,
+                    Some(DiagnosticId::Error(E1001.kind)),
+                );
+                self.add_diagnostic(diag);
+            }
         }
         self
     }
@@ -228,6 +238,7 @@ impl Handler {
 #[derive(Debug, Clone)]
 pub enum ParseError {
     UnexpectedToken { expected: Vec<String>, got: String },
+    UnicodeError,
 }
 
 impl ParseError {
@@ -239,6 +250,10 @@ impl ParseError {
                 .collect::<Vec<String>>(),
             got: got.to_string(),
         }
+    }
+
+    pub fn unicode_error() -> Self {
+        ParseError::UnicodeError
     }
 }
 

--- a/kclvm/parser/src/parser/expr.rs
+++ b/kclvm/parser/src/parser/expr.rs
@@ -1992,7 +1992,8 @@ impl<'a> Parser<'a> {
                 let value = match result {
                     Some(value) => value,
                     None => {
-                        self.sess.struct_token_error(&[token::LitKind::Integer.into()], token);
+                        self.sess
+                            .struct_token_error(&[token::LitKind::Integer.into()], token);
                     }
                 };
                 match lk.suffix {
@@ -2005,7 +2006,8 @@ impl<'a> Parser<'a> {
                 let value = match result {
                     Ok(value) => value,
                     _ => {
-                        self.sess.struct_token_error(&[token::LitKind::Float.into()], token);
+                        self.sess
+                            .struct_token_error(&[token::LitKind::Float.into()], token);
                     }
                 };
                 (None, NumberLitValue::Float(value))

--- a/kclvm/parser/src/tests.rs
+++ b/kclvm/parser/src/tests.rs
@@ -2,8 +2,8 @@ use std::panic::{catch_unwind, set_hook};
 
 use crate::*;
 
-use expect_test::{expect, Expect};
 use core::any::Any;
+use expect_test::{expect, Expect};
 
 fn check_parsing_file_ast_json(filename: &str, src: &str, expect: Expect) {
     let m = parse_file(filename, Some(src.into())).unwrap();
@@ -76,7 +76,7 @@ c = 3 # comment4444
     );
 }
 
-pub fn check_result_panic_info(result: Result<(), Box<dyn Any + Send>>){
+pub fn check_result_panic_info(result: Result<(), Box<dyn Any + Send>>) {
     match result {
         Err(e) => match e.downcast::<String>() {
             Ok(_v) => {
@@ -89,15 +89,12 @@ pub fn check_result_panic_info(result: Result<(), Box<dyn Any + Send>>){
     };
 }
 
-const PARSE_EXPR_INVALID_TEST_CASES: &[&'static str; 3] = &[
-    "fs1_i1re1~s",
-    "fh==-h==-",
-    "8_________i"
-];
+const PARSE_EXPR_INVALID_TEST_CASES: &[&'static str; 4] =
+    &["fs1_i1re1~s", "fh==-h==-", "8_________i", "-\u{feff}sjda"];
 
 #[test]
 pub fn test_parse_expr_invalid() {
-    for case in PARSE_EXPR_INVALID_TEST_CASES{
+    for case in PARSE_EXPR_INVALID_TEST_CASES {
         set_hook(Box::new(|_| {}));
         let result = catch_unwind(|| {
             parse_expr(&case);

--- a/kclvm/runner/Cargo.lock
+++ b/kclvm/runner/Cargo.lock
@@ -521,6 +521,7 @@ dependencies = [
  "rustc_span",
  "serde",
  "serde_json",
+ "str_indices",
  "tracing",
  "unicode_names2",
 ]
@@ -1301,6 +1302,12 @@ dependencies = [
  "psm",
  "winapi",
 ]
+
+[[package]]
+name = "str_indices"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d9199fa80c817e074620be84374a520062ebac833f358d74b37060ce4a0f2c0"
 
 [[package]]
 name = "strsim"

--- a/kclvm/sema/Cargo.lock
+++ b/kclvm/sema/Cargo.lock
@@ -570,6 +570,7 @@ dependencies = [
  "rustc_span",
  "serde",
  "serde_json",
+ "str_indices",
  "tracing",
  "unicode_names2",
 ]
@@ -1363,6 +1364,12 @@ dependencies = [
  "psm",
  "winapi",
 ]
+
+[[package]]
+name = "str_indices"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d9199fa80c817e074620be84374a520062ebac833f358d74b37060ce4a0f2c0"
 
 [[package]]
 name = "syn"

--- a/kclvm/tools/Cargo.lock
+++ b/kclvm/tools/Cargo.lock
@@ -479,6 +479,7 @@ dependencies = [
  "rustc_span",
  "serde",
  "serde_json",
+ "str_indices",
  "tracing",
  "unicode_names2",
 ]
@@ -1211,6 +1212,12 @@ dependencies = [
  "psm",
  "winapi",
 ]
+
+[[package]]
+name = "str_indices"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d9199fa80c817e074620be84374a520062ebac833f358d74b37060ce4a0f2c0"
 
 [[package]]
 name = "syn"


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 

fix #65 
<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

kclvm/error/src/lib.rs
kclvm/parser/src/lexer/mod.rs
kclvm/parser/src/parser/expr.rs
kclvm/parser/src/session/mod.rs
kclvm/parser/src/tests.rs
<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kusionstack/KCLVM/kclvm-parser 
-->

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

Add check unicode char in kclvm-parser before parsing "->". 
After parsing "-", kclvm will lookahead(1) to check whether the next char is ">". 
lookahead(1) will slice the remaining string with length 1. 
If the new char is an unicode char with length 3 (or more than 1), the rust will panic. 

So, method "check_next_token_legal" is added and called during parsing "-" to check length of the next char.
If length of the next char is greater than 1, the  "check_next_token_legal" would report "UnicodeError".

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
None
```