### PR TITLE
Fix(resolver): fix incorrect position info of CannotFindModule Error.

### DIFF
--- a/kclvm/sema/src/resolver/global.rs
+++ b/kclvm/sema/src/resolver/global.rs
@@ -170,7 +170,7 @@ impl<'ctx> Resolver<'ctx> {
                         pos: Position {
                             filename: self.ctx.filename.clone(),
                             line: 1,
-                            column: Some(1),
+                            column: None,
                         },
                         style: Style::Line,
                         message: format!("pkgpath {} not found in the program", self.ctx.pkgpath),

--- a/kclvm/sema/src/resolver/import.rs
+++ b/kclvm/sema/src/resolver/import.rs
@@ -39,7 +39,7 @@ impl<'ctx> Resolver<'ctx> {
                                     pos: Position {
                                         filename: m.filename.clone(),
                                         line: stmt.line,
-                                        column: Some(1),
+                                        column: None,
                                     },
                                     style: Style::Line,
                                     message: format!(
@@ -59,7 +59,7 @@ impl<'ctx> Resolver<'ctx> {
                                         pos: Position {
                                             filename: self.ctx.filename.clone(),
                                             line: stmt.line,
-                                            column: Some(1),
+                                            column: None,
                                         },
                                         style: Style::Line,
                                         message: format!(

--- a/kclvm/sema/src/resolver/test_fail_data/cannot_find_module.k
+++ b/kclvm/sema/src/resolver/test_fail_data/cannot_find_module.k
@@ -1,0 +1,1 @@
+import non_exist_file

--- a/kclvm/sema/src/resolver/tests.rs
+++ b/kclvm/sema/src/resolver/tests.rs
@@ -100,3 +100,14 @@ fn test_resolve_program_cycle_reference_fail() {
         assert_eq!(diag.messages[0].message, msg.to_string(),);
     }
 }
+
+#[test]
+fn test_cannot_find_module() {
+    let mut program = load_program(
+        &["./src/resolver/test_fail_data/cannot_find_module.k"],
+        None,
+    )
+    .unwrap();
+    let scope = resolve_program(&mut program);
+    assert_eq!(scope.diagnostics[0].messages[0].pos.column, None);
+}


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y fix #126

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kusionstack/KCLVM/kclvm-parser 
-->

sema/resolver/global.rs
sema/resolver/import.rs

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->
There is an incorrect position of ConnotFindModule Error. When a CannotFindModule error is triggered (e.g., importing a non-existent file), the error message is indicated at x:2(line: x and column: 2), but by convention it should be x:1 or just line x. Now fix it to just output the line number.
```
KCL Error [CannotFindModule]
---> File ./test.k:1
1 |import non_existent_file
```

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other


<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
None
```
