### PR TITLE
Feat(compiler-base): reuse kclvm bug macro.

### DIFF
--- a/kclvm/compiler_base/error/src/diagnostic/components.rs
+++ b/kclvm/compiler_base/error/src/diagnostic/components.rs
@@ -1,6 +1,7 @@
 //! 'components.rs' defines all components that builtin in compiler_base_error.
-use super::{style::DiagnosticStyle, Component};
 use rustc_errors::styled_buffer::StyledBuffer;
+
+use super::{style::DiagnosticStyle, Component};
 
 /// `Label` can be considered as a component of diagnostic to display a short label message in `Diagnositc`.
 /// `Label` provides "error", "warning", "note" and "Help" four kinds of labels.

--- a/kclvm/compiler_base/macros/Cargo.toml
+++ b/kclvm/compiler_base/macros/Cargo.toml
@@ -1,16 +1,8 @@
 [package]
-name = "compiler_base"
+name = "compiler_base_macros"
 version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-
-[workspace]
-members = [
-    "macros",
-    "span",
-    "error",
-    "3rdparty/rustc_errors",
-]

--- a/kclvm/compiler_base/macros/src/bug.rs
+++ b/kclvm/compiler_base/macros/src/bug.rs
@@ -1,0 +1,48 @@
+use std::{error, fmt, panic};
+
+/// `bug!` macro is used to report compiler internal bug.
+/// You can use bug! macros directly by adding `#[macro_use]extern crate kclvm_error;`
+/// in the lib.rs, and then call as follows:
+/// ```no_check
+/// bug!();
+/// bug!("an error msg");
+/// bug!("an error msg with string format {}", "msg");
+/// ```
+#[macro_export]
+macro_rules! bug {
+    () => ( $crate::bug::bug("impossible case reached") );
+    ($msg:expr) => ({ $crate::bug::bug(&format!($msg)) });
+    ($msg:expr,) => ({ $crate::bug::bug($msg) });
+    ($fmt:expr, $($arg:tt)+) => ({
+        $crate::bug::bug(&format!($fmt, $($arg)+))
+    });
+}
+
+/// Signifies that the compiler died with an explicit call to `.bug`
+/// rather than a failed assertion, etc.
+#[derive(Clone, Debug)]
+pub struct ExplicitBug {
+    msg: String,
+}
+
+impl fmt::Display for ExplicitBug {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Internal error, please report a bug to us. The error message is: {}",
+            self.msg
+        )
+    }
+}
+
+impl error::Error for ExplicitBug {}
+
+#[inline]
+pub fn bug(msg: &str) -> ! {
+    panic!(
+        "{}",
+        ExplicitBug {
+            msg: msg.to_string()
+        }
+    );
+}

--- a/kclvm/compiler_base/macros/src/lib.rs
+++ b/kclvm/compiler_base/macros/src/lib.rs
@@ -1,0 +1,5 @@
+#[macro_use]
+pub mod bug;
+
+#[cfg(test)]
+mod tests;

--- a/kclvm/compiler_base/macros/src/tests.rs
+++ b/kclvm/compiler_base/macros/src/tests.rs
@@ -1,0 +1,46 @@
+mod test_bug {
+    use crate::bug;
+
+    #[test]
+    fn test_bug_macro() {
+        std::panic::set_hook(Box::new(|_| {}));
+        let result = std::panic::catch_unwind(|| {
+            bug!();
+        });
+        assert!(result.is_err());
+        let result = std::panic::catch_unwind(|| {
+            bug!("an error msg");
+        });
+        assert!(result.is_err());
+        match result {
+            Ok(_) => panic!("test bug!() failed"),
+            Err(panic_err) => {
+                let err_message = if let Some(s) = panic_err.downcast_ref::<String>() {
+                    (*s).clone()
+                } else {
+                    panic!("test bug!() failed")
+                };
+                assert_eq!(
+                    err_message,
+                    "Internal error, please report a bug to us. The error message is: an error msg"
+                );
+            }
+        }
+
+        let result = std::panic::catch_unwind(|| {
+            bug!("an error msg with string format {}", "msg");
+        });
+        assert!(result.is_err());
+        match result {
+            Ok(_) => panic!("test bug!() failed"),
+            Err(panic_err) => {
+                let err_message = if let Some(s) = panic_err.downcast_ref::<String>() {
+                    (*s).clone()
+                } else {
+                    panic!("test bug!() failed")
+                };
+                assert_eq!(err_message, "Internal error, please report a bug to us. The error message is: an error msg with string format msg");
+            }
+        }
+    }
+}

--- a/kclvm/compiler_base/span/Cargo.toml
+++ b/kclvm/compiler_base/span/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "span"
+name = "compiler_base_span"
 version = "0.1.0"
 edition = "2021"
 


### PR DESCRIPTION

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 

issue #115

#### 2. What is the scope of this PR (e.g. component or file name):

compiler_base/macros/bug.rs

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [x] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

init crate 'macros' in compiler_base.
reuse bug macro 'bug!()' in compiler_base/macros/src/bug.rs.
add test cases for 'bug!()' in compiler_base/macros/src/tests.rs.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

compiler_base/macros/tests.rs

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
None
```
