### PR TITLE
Refactor(compiler-base): Replaced `DiagnosticStyle` in `trait Component` with generic `T: Clone + PartialEq + Eq + Style`.

### DIFF
--- a/kclvm/compiler_base/error/src/diagnostic/components.rs
+++ b/kclvm/compiler_base/error/src/diagnostic/components.rs
@@ -1,4 +1,4 @@
-//! 'components.rs' defines all components that builtin in compiler_base_error.
+//! 'components.rs' defines all components with style `DiagnosticStyle` that builtin in compiler_base_error.
 use super::{style::DiagnosticStyle, Component};
 use rustc_errors::styled_buffer::StyledBuffer;
 
@@ -50,14 +50,5 @@ impl Component<DiagnosticStyle> for Label {
             sb.appendl(c.as_str(), Some(DiagnosticStyle::Helpful));
             sb.appendl("]", Some(DiagnosticStyle::Helpful));
         }
-    }
-}
-
-/// `String` can be considered as a component of diagnostic.
-///
-/// The result of component `String` rendering is a `String` who has no style.
-impl Component<DiagnosticStyle> for String {
-    fn format(&self, sb: &mut StyledBuffer<DiagnosticStyle>) {
-        sb.appendl(&self, None);
     }
 }

--- a/kclvm/compiler_base/error/src/diagnostic/components.rs
+++ b/kclvm/compiler_base/error/src/diagnostic/components.rs
@@ -34,7 +34,7 @@ pub enum Label {
     Help,
 }
 
-impl Component for Label {
+impl Component<DiagnosticStyle> for Label {
     fn format(&self, sb: &mut StyledBuffer<DiagnosticStyle>) {
         let (text, style, code) = match self {
             Label::Error(ecode) => ("error", DiagnosticStyle::NeedFix, Some(ecode)),
@@ -56,7 +56,7 @@ impl Component for Label {
 /// `String` can be considered as a component of diagnostic.
 ///
 /// The result of component `String` rendering is a `String` who has no style.
-impl Component for String {
+impl Component<DiagnosticStyle> for String {
     fn format(&self, sb: &mut StyledBuffer<DiagnosticStyle>) {
         sb.appendl(&self, None);
     }

--- a/kclvm/compiler_base/error/src/diagnostic/mod.rs
+++ b/kclvm/compiler_base/error/src/diagnostic/mod.rs
@@ -9,7 +9,7 @@ mod tests;
 
 /// 'Component' specifies the method `format()` that all diagnostic components should implement.
 /// 
-/// 'Component' decouples 'structures' and 'theme' during formatting diagnostic components.
+/// 'Component' decouples 'structure' and 'theme' during formatting diagnostic components.
 /// `T: Clone + PartialEq + Eq + Style` is responsible for 'theme' such as colors/fonts in the component formatting.
 /// `format()` organizes the 'structure' of diagnostic components.
 pub trait Component<T>
@@ -31,7 +31,7 @@ where
     ///         sb.pushs(&self.text, Some(DiagnosticStyle::Logo));
     ///     }
     /// }
-    ///
+    /// 
     /// ```
     fn format(&self, sb: &mut StyledBuffer<T>);
 }

--- a/kclvm/compiler_base/error/src/diagnostic/mod.rs
+++ b/kclvm/compiler_base/error/src/diagnostic/mod.rs
@@ -8,6 +8,10 @@ pub mod style;
 mod tests;
 
 /// 'Component' specifies the method `format()` that all diagnostic components should implement.
+/// 
+/// 'Component' decouples 'structures' and 'theme' during formatting diagnostic components.
+/// `T: Clone + PartialEq + Eq + Style` is responsible for 'theme' such as colors/fonts in the component formatting.
+/// `format()` organizes the 'structure' of diagnostic components.
 pub trait Component<T>
 where
     T: Clone + PartialEq + Eq + Style,

--- a/kclvm/compiler_base/error/src/diagnostic/mod.rs
+++ b/kclvm/compiler_base/error/src/diagnostic/mod.rs
@@ -117,3 +117,15 @@ where
         }
     }
 }
+
+/// `String` can be considered as a component of diagnostic with no style.
+///
+/// The result of component `String` rendering is a `String` who has no style.
+impl<T> Component<T> for String
+where
+    T: Clone + PartialEq + Eq + Style,
+{
+    fn format(&self, sb: &mut StyledBuffer<T>) {
+        sb.appendl(&self, None);
+    }
+}


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 

issue #115

#### 2. What is the scope of this PR (e.g. component or file name):

compiler_base/error/diagnostic

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [x] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

Replaced `DiagnosticStyle` in `trait Component` with generic `T: Clone + PartialEq + Eq + Style`, So that `Components` can support more Styles.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

compiler_base/error/diagnostic/tests.rs

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
None
```
