### PR TITLE
Feat(Compiler-Base): Reuse kclvm emitter

### DIFF
--- a/kclvm/compiler_base/3rdparty/rustc_errors/Cargo.toml
+++ b/kclvm/compiler_base/3rdparty/rustc_errors/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2021"
 
 [dependencies]
 termcolor = "1.0"
+
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["handleapi", "synchapi", "winbase"] }

--- a/kclvm/compiler_base/3rdparty/rustc_errors/src/README.md
+++ b/kclvm/compiler_base/3rdparty/rustc_errors/src/README.md
@@ -1,8 +1,9 @@
-Porting ['rustc_errors/styled_buffer.rs'] code here to enable code reuse due to the unstable and unreusable of the ['rustc_errors'] crate now.
-We mainly reuse helper structs and functions like `StyledBuffer`, `StyledString` to render text in Compiler-Base.
+Porting ['rustc_errors/styled_buffer.rs'] and ['rustc_errors/lock.rs'] code here to enable code reuse due to the unstable and unreusable of the ['rustc_errors'] crate now.
+We mainly reuse helper structs and functions like `StyledBuffer`, `StyledString` to render text in Compiler-Base, and reuse helper function `acquire_global_lock` to emit the diagnostic messages.
+
 Note: the structs and functions here exist as implementations and will not be exposed to other crates directly.
 
-Reuse 'styled_buffer.rs' in 'rustc_errors', 
+Reuse 'styled_buffer.rs' and 'lock.rs' in 'rustc_errors', 
 and 'styled_buffer.rs' has been modified to fit the feature of 'Compiler-Base'.
 
 We modified some features on porting code:

--- a/kclvm/compiler_base/3rdparty/rustc_errors/src/lib.rs
+++ b/kclvm/compiler_base/3rdparty/rustc_errors/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! - add some test cases for 'StyledBuffer'.
 use termcolor::ColorSpec;
-
+pub mod lock;
 pub mod styled_buffer;
 
 /// 'Style' is a trait used to specify the user customize 'XXXStyle' can be accepted by 'StyleBuffer'.

--- a/kclvm/compiler_base/3rdparty/rustc_errors/src/lock.rs
+++ b/kclvm/compiler_base/3rdparty/rustc_errors/src/lock.rs
@@ -1,0 +1,93 @@
+//! Bindings to acquire a global named lock.
+//!
+//! This is intended to be used to synchronize multiple compiler processes to
+//! ensure that we can output complete errors without interleaving on Windows.
+//! Note that this is currently only needed for allowing only one 32-bit MSVC
+//! linker to execute at once on MSVC hosts, so this is only implemented for
+//! `cfg(windows)`. Also note that this may not always be used on Windows,
+//! only when targeting 32-bit MSVC.
+//!
+//! For more information about why this is necessary, see where this is called.
+
+use std::any::Any;
+
+#[cfg(windows)]
+pub fn acquire_global_lock(name: &str) -> Box<dyn Any> {
+    use std::ffi::CString;
+    use std::io;
+
+    use winapi::shared::ntdef::HANDLE;
+    use winapi::um::handleapi::CloseHandle;
+    use winapi::um::synchapi::{CreateMutexA, ReleaseMutex, WaitForSingleObject};
+    use winapi::um::winbase::{INFINITE, WAIT_ABANDONED, WAIT_OBJECT_0};
+
+    struct Handle(HANDLE);
+
+    impl Drop for Handle {
+        fn drop(&mut self) {
+            unsafe {
+                CloseHandle(self.0);
+            }
+        }
+    }
+
+    struct Guard(Handle);
+
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            unsafe {
+                ReleaseMutex((self.0).0);
+            }
+        }
+    }
+
+    let cname = CString::new(name).unwrap();
+    unsafe {
+        // Create a named mutex, with no security attributes and also not
+        // acquired when we create it.
+        //
+        // This will silently create one if it doesn't already exist, or it'll
+        // open up a handle to one if it already exists.
+        let mutex = CreateMutexA(std::ptr::null_mut(), 0, cname.as_ptr());
+        if mutex.is_null() {
+            panic!(
+                "failed to create global mutex named `{}`: {}",
+                name,
+                io::Error::last_os_error()
+            );
+        }
+        let mutex = Handle(mutex);
+
+        // Acquire the lock through `WaitForSingleObject`.
+        //
+        // A return value of `WAIT_OBJECT_0` means we successfully acquired it.
+        //
+        // A return value of `WAIT_ABANDONED` means that the previous holder of
+        // the thread exited without calling `ReleaseMutex`. This can happen,
+        // for example, when the compiler crashes or is interrupted via ctrl-c
+        // or the like. In this case, however, we are still transferred
+        // ownership of the lock so we continue.
+        //
+        // If an error happens.. well... that's surprising!
+        match WaitForSingleObject(mutex.0, INFINITE) {
+            WAIT_OBJECT_0 | WAIT_ABANDONED => {}
+            code => {
+                panic!(
+                    "WaitForSingleObject failed on global mutex named \
+                        `{}`: {} (ret={:x})",
+                    name,
+                    io::Error::last_os_error(),
+                    code
+                );
+            }
+        }
+
+        // Return a guard which will call `ReleaseMutex` when dropped.
+        Box::new(Guard(mutex))
+    }
+}
+
+#[cfg(not(windows))]
+pub fn acquire_global_lock(_name: &str) -> Box<dyn Any> {
+    Box::new(())
+}

--- a/kclvm/compiler_base/error/Cargo.toml
+++ b/kclvm/compiler_base/error/Cargo.toml
@@ -7,5 +7,6 @@ edition = "2021"
 
 [dependencies]
 compiler_base_span = {path = "../span", version = "0.1.0"}
+compiler_base_macros = {path = "../macros", version = "0.1.0"}
 rustc_errors = {path="../3rdparty/rustc_errors", version="0.1.0"}
 termcolor = "1.0"

--- a/kclvm/compiler_base/error/Cargo.toml
+++ b/kclvm/compiler_base/error/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-compiler_base_span = {path = "../span", version = "0.1.0"}
 compiler_base_macros = {path = "../macros", version = "0.1.0"}
 rustc_errors = {path="../3rdparty/rustc_errors", version="0.1.0"}
 termcolor = "1.0"

--- a/kclvm/compiler_base/error/Cargo.toml
+++ b/kclvm/compiler_base/error/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+compiler_base_span = {path = "../span", version = "0.1.0"}
 rustc_errors = {path="../3rdparty/rustc_errors", version="0.1.0"}
 termcolor = "1.0"

--- a/kclvm/compiler_base/error/src/diagnostic/components.rs
+++ b/kclvm/compiler_base/error/src/diagnostic/components.rs
@@ -2,8 +2,6 @@
 use super::{style::DiagnosticStyle, Component};
 use rustc_errors::styled_buffer::StyledBuffer;
 
-use super::{style::DiagnosticStyle, Component};
-
 /// `Label` can be considered as a component of diagnostic to display a short label message in `Diagnositc`.
 /// `Label` provides "error", "warning", "note" and "Help" four kinds of labels.
 ///

--- a/kclvm/compiler_base/error/src/diagnostic/mod.rs
+++ b/kclvm/compiler_base/error/src/diagnostic/mod.rs
@@ -8,7 +8,7 @@ pub mod style;
 mod tests;
 
 /// 'Component' specifies the method `format()` that all diagnostic components should implement.
-/// 
+///
 /// 'Component' decouples 'structure' and 'theme' during formatting diagnostic components.
 /// `T: Clone + PartialEq + Eq + Style` is responsible for 'theme' such as colors/fonts in the component formatting.
 /// `format()` organizes the 'structure' of diagnostic components.
@@ -31,7 +31,7 @@ where
     ///         sb.pushs(&self.text, Some(DiagnosticStyle::Logo));
     ///     }
     /// }
-    /// 
+    ///
     /// ```
     fn format(&self, sb: &mut StyledBuffer<T>);
 }

--- a/kclvm/compiler_base/error/src/diagnostic/mod.rs
+++ b/kclvm/compiler_base/error/src/diagnostic/mod.rs
@@ -91,7 +91,7 @@ pub struct Diagnostic<T>
 where
     T: Clone + PartialEq + Eq + Style,
 {
-    pub components: Vec<Box<dyn Component<T>>>,
+    components: Vec<Box<dyn Component<T>>>,
 }
 
 impl<T> Diagnostic<T>

--- a/kclvm/compiler_base/error/src/diagnostic/mod.rs
+++ b/kclvm/compiler_base/error/src/diagnostic/mod.rs
@@ -91,7 +91,7 @@ pub struct Diagnostic<T>
 where
     T: Clone + PartialEq + Eq + Style,
 {
-    components: Vec<Box<dyn Component<T>>>,
+    pub components: Vec<Box<dyn Component<T>>>,
 }
 
 impl<T> Diagnostic<T>

--- a/kclvm/compiler_base/error/src/emitter.rs
+++ b/kclvm/compiler_base/error/src/emitter.rs
@@ -1,5 +1,14 @@
 //! 'emitter.rs' defines the diagnostic emitter,
 //! which is responsible for displaying the rendered diagnostic.
+//!
+//! Provides trait `Emitter` to support customizing the diagnostic emitter.
+//! To customize your own `Emitter`, you need to make it implement trait `Emitter`.
+//!
+//! The builtin emitters currently provided in 'emitter.rs' are as follows:
+//!
+//! - `EmitterWriter` is responsible for rendering diagnostic as strings and displaying them to the terminal.
+//! - TODO(zongz): `EmitterAPI` is responsible for serializing diagnostic and sent them to the API.
+//!
 use crate::diagnostic::{Component, Diagnostic};
 use compiler_base_macros::bug;
 use rustc_errors::{
@@ -17,7 +26,7 @@ use termcolor::{Buffer, BufferWriter, ColorChoice, ColorSpec, StandardStream, Wr
 /// To customize your own `Emitter`, you could do the following steps:
 ///
 /// # Examples
-/// 
+///
 /// 1. Define your Emitter:
 ///
 /// ```no_run rust
@@ -55,13 +64,13 @@ use termcolor::{Buffer, BufferWriter, ColorChoice, ColorSpec, StandardStream, Wr
 /// 2. Use your Emitter with diagnostic:
 ///
 /// ```no_run rust
-/// 
+///
 /// // Create a diagnostic for emitting.
 /// let mut diagnostic = Diagnostic::<DiagnosticStyle>::new();
-/// 
+///
 /// // Create a string component wrapped by `Box<>`.
 /// let msg = Box::new(": this is an error!".to_string());
-/// 
+///
 /// // Add it to `Diagnostic`.
 /// diagnostic.append_component(msg);
 ///

--- a/kclvm/compiler_base/error/src/emitter.rs
+++ b/kclvm/compiler_base/error/src/emitter.rs
@@ -16,6 +16,8 @@ use termcolor::{Buffer, BufferWriter, ColorChoice, ColorSpec, StandardStream, Wr
 ///
 /// To customize your own `Emitter`, you could do the following steps:
 ///
+/// # Examples
+/// 
 /// 1. Define your Emitter:
 ///
 /// ```no_run rust
@@ -139,14 +141,6 @@ enum Destination {
     /// `Buffer` implements `io::Write and io::WriteColor`.
     Buffered(Box<BufferWriter>, Buffer),
 }
-
-// Convert terminal to writable terminal
-// On Unix systems, a buffer will be create for `BufferWriter` and return `&mut BufferWriter` and buffer.
-// On Windows, it will still return the `&mut StandardStream`.
-// enum WritableDst<'a> {
-//     Terminal(&'a mut StandardStream),
-//     Buffered(&'a mut BufferWriter, Buffer),
-// }
 
 impl Destination {
     fn from_stderr() -> Self {

--- a/kclvm/compiler_base/error/src/emitter.rs
+++ b/kclvm/compiler_base/error/src/emitter.rs
@@ -1,0 +1,168 @@
+use crate::diagnostic::Diagnostic;
+
+use compiler_base_span::SourceMap;
+use rustc_errors::{
+    styled_buffer::{StyledBuffer, StyledString},
+    Style,
+};
+use std::io::{self, Write};
+use std::sync::Arc;
+use termcolor::{BufferWriter, ColorChoice, ColorSpec, StandardStream, WriteColor};
+
+/// Emitter trait for emitting errors.
+pub trait Emitter<T>
+where
+    T: Clone + PartialEq + Eq + Style,
+{
+    fn format_diagnostic(&mut self, diag: &Diagnostic<T>) -> StyledBuffer<T>;
+    /// Emit a structured diagnostic.
+    fn emit_diagnostic(&mut self, diag: &Diagnostic<T>);
+    /// Checks if we can use colors in the current output stream.
+    fn supports_color(&self) -> bool {
+        false
+    }
+}
+
+/// Emitter writer.
+pub struct EmitterWriter {
+    dst: Destination,
+    short_message: bool,
+    source_map: Option<Arc<SourceMap>>,
+}
+
+impl Default for EmitterWriter {
+    fn default() -> Self {
+        Self {
+            dst: Destination::from_stderr(),
+            short_message: false,
+            source_map: None,
+        }
+    }
+}
+
+impl EmitterWriter {
+    pub fn from_stderr(source_map: Arc<SourceMap>) -> Self {
+        Self {
+            dst: Destination::from_stderr(),
+            short_message: false,
+            source_map: Some(source_map),
+        }
+    }
+}
+
+/// Emit destinations
+pub enum Destination {
+    Terminal(StandardStream),
+    Buffered(BufferWriter),
+    // The bool denotes whether we should be emitting ansi color codes or not
+    Raw(Box<(dyn Write + Send)>, bool),
+}
+
+impl Destination {
+    #[allow(dead_code)]
+    pub fn from_raw(dst: Box<dyn Write + Send>, colored: bool) -> Self {
+        Destination::Raw(dst, colored)
+    }
+
+    pub fn from_stderr() -> Self {
+        // On Windows we'll be performing global synchronization on the entire
+        // system for emitting rustc errors, so there's no need to buffer
+        // anything.
+        //
+        // On non-Windows we rely on the atomicity of `write` to ensure errors
+        // don't get all jumbled up.
+        if !cfg!(windows) {
+            Destination::Terminal(StandardStream::stderr(ColorChoice::Auto))
+        } else {
+            Destination::Buffered(BufferWriter::stderr(ColorChoice::Auto))
+        }
+    }
+
+    fn supports_color(&self) -> bool {
+        match *self {
+            Self::Terminal(ref stream) => stream.supports_color(),
+            Self::Buffered(ref buffer) => buffer.buffer().supports_color(),
+            Self::Raw(_, supports_color) => supports_color,
+        }
+    }
+
+    fn set_color(&mut self, color: &ColorSpec) -> io::Result<()> {
+        match *self {
+            Destination::Terminal(ref mut t) => t.set_color(color),
+            Destination::Buffered(ref mut t) => t.buffer().set_color(color),
+            Destination::Raw(_, _) => Ok(()),
+        }
+    }
+
+    fn reset(&mut self) -> io::Result<()> {
+        match *self {
+            Destination::Terminal(ref mut t) => t.reset(),
+            Destination::Buffered(ref mut t) => t.buffer().reset(),
+            Destination::Raw(..) => Ok(()),
+        }
+    }
+}
+
+impl<'a> Write for Destination {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        match *self {
+            Destination::Terminal(ref mut t) => t.write(bytes),
+            Destination::Buffered(ref mut t) => t.buffer().write(bytes),
+            Destination::Raw(ref mut t, _) => t.write(bytes),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match *self {
+            Destination::Terminal(ref mut t) => t.flush(),
+            Destination::Buffered(ref mut t) => t.buffer().flush(),
+            Destination::Raw(ref mut t, _) => t.flush(),
+        }
+    }
+}
+
+impl<T> Emitter<T> for EmitterWriter
+where
+    T: Clone + PartialEq + Eq + Style,
+{
+    fn supports_color(&self) -> bool {
+        self.dst.supports_color()
+    }
+
+    fn emit_diagnostic(&mut self, diag: &Diagnostic<T>) {
+        let buffer = self.format_diagnostic(diag);
+        if let Err(e) = emit_to_destination(&buffer.render(), &mut self.dst, self.short_message) {
+            panic!("failed to emit error: {}", e)
+        }
+    }
+
+    fn format_diagnostic(&mut self, diag: &Diagnostic<T>) -> StyledBuffer<T> {
+        let mut sb = StyledBuffer::<T>::new();
+        for component in &diag.components {
+            component.format(&mut sb)
+        }
+        sb
+    }
+}
+
+fn emit_to_destination<T>(
+    rendered_buffer: &[Vec<StyledString<T>>],
+    dst: &mut Destination,
+    short_message: bool,
+) -> io::Result<()>
+where
+    T: Clone + PartialEq + Eq + Style,
+{
+    for (pos, line) in rendered_buffer.iter().enumerate() {
+        for part in line {
+            dst.set_color(&part.style.as_ref().unwrap().render_style_to_color_spec())?;
+            write!(dst, "{}", part.text)?;
+            dst.reset()?;
+        }
+        if !short_message || pos != rendered_buffer.len() - 1 {
+            writeln!(dst)?;
+        }
+    }
+    dst.flush()?;
+    Ok(())
+}

--- a/kclvm/compiler_base/error/src/emitter.rs
+++ b/kclvm/compiler_base/error/src/emitter.rs
@@ -1,6 +1,7 @@
 //! 'emitter.rs' defines the diagnostic emitter,
 //! which is responsible for displaying the rendered diagnostic.
 use crate::diagnostic::{Component, Diagnostic};
+use compiler_base_macros::bug;
 use rustc_errors::{
     styled_buffer::{StyledBuffer, StyledString},
     Style,
@@ -173,7 +174,7 @@ where
     fn emit_diagnostic(&mut self, diag: &Diagnostic<T>) {
         let buffer = self.format_diagnostic(diag);
         if let Err(e) = emit_to_destination(&buffer.render(), &mut self.dst, self.short_message) {
-            panic!("failed to emit error: {}", e)
+            bug!("failed to emit diagnositc: {}", e)
         }
     }
 

--- a/kclvm/compiler_base/error/src/emitter.rs
+++ b/kclvm/compiler_base/error/src/emitter.rs
@@ -1,13 +1,14 @@
 //! 'emitter.rs' defines the diagnostic emitter,
 //! which is responsible for displaying the rendered diagnostic.
-//!
-//! Provides trait `Emitter` to support customizing the diagnostic emitter.
-//! To customize your own `Emitter`, you need to make it implement trait `Emitter`.
-//!
-//! The builtin emitters currently provided in 'emitter.rs' are as follows:
-//!
-//! - `EmitterWriter` is responsible for rendering diagnostic as strings and displaying them to the terminal.
-//! - TODO(zongz): `EmitterAPI` is responsible for serializing diagnostics and sent them to the API.
+//! 
+//! The crate providers `Emitter` trait to define the interface that diagnostic emitter should implement.
+//! and also provider a built-in emitters:
+//! 
+//!  + `TerminalEmitter` is responsible for emitting diagnostic to the terminal.
+//!  + TODO(zongz): `EmitterAPI` is responsible for serializing diagnostics and emitting them to the API.
+//! 
+//！Besides, it's easy define your customized `Emitter` by implementing `Emitter` trait.
+//! For more information about how to define your customized `Emitter`, see the doc above `Emitter` trait.
 //!
 use crate::diagnostic::{Component, Diagnostic};
 use compiler_base_macros::bug;
@@ -96,21 +97,21 @@ where
     }
 }
 
-/// `EmitterWriter` is a concrete struct of trait `Emitter` based on `termcolor1.0`.
+/// `TerminalEmitter` implements trait `Emitter` based on `termcolor1.0` 
+/// for rendering diagnostic as strings and displaying them to the terminal.
 /// 
-/// It is responsible for rendering diagnostic as strings and displaying them to the terminal.
 /// `termcolor1.0` supports displaying colorful string to terminal.
 ///
 /// # Examples
 ///
 /// ```rust
 /// # use crate::compiler_base_error::Emitter;
-/// # use compiler_base_error::EmitterWriter;
+/// # use compiler_base_error::TerminalEmitter;
 /// # use compiler_base_error::diagnostic::{components::Label, Diagnostic};
 /// # use compiler_base_error::diagnostic::style::DiagnosticStyle;
 ///
-/// // 1. Create a EmitterWriter
-/// let mut emitter_writer = EmitterWriter::default();
+/// // 1. Create a TerminalEmitter
+/// let mut term_emitter = TerminalEmitter::default();
 ///
 /// // 2. Create a diagnostic for emitting.
 /// let mut diagnostic = Diagnostic::<DiagnosticStyle>::new();
@@ -124,14 +125,14 @@ where
 /// diagnostic.append_component(msg);
 ///
 /// // 5. Emit the diagnostic.
-/// emitter_writer.emit_diagnostic(&diagnostic);
+/// term_emitter.emit_diagnostic(&diagnostic);
 /// ```
-pub struct EmitterWriter {
+pub struct TerminalEmitter {
     dst: Destination,
     short_message: bool,
 }
 
-impl Default for EmitterWriter {
+impl Default for TerminalEmitter {
     fn default() -> Self {
         Self {
             dst: Destination::from_stderr(),
@@ -211,7 +212,7 @@ impl<'a> Write for Destination {
     }
 }
 
-impl<T> Emitter<T> for EmitterWriter
+impl<T> Emitter<T> for TerminalEmitter
 where
     T: Clone + PartialEq + Eq + Style,
 {

--- a/kclvm/compiler_base/error/src/emitter.rs
+++ b/kclvm/compiler_base/error/src/emitter.rs
@@ -184,7 +184,7 @@ where
     // On Windows, styling happens through calls to a terminal API. This prevents us from using the
     // same buffering approach.  Instead, we use a global Windows mutex, which we acquire long
     // enough to output the full error message, then we release.
-    let _buffer_lock = lock::acquire_global_lock("rustc_errors");
+    let _buffer_lock = lock::acquire_global_lock("compiler_base_errors");
     for (pos, line) in rendered_buffer.iter().enumerate() {
         for part in line {
             dst.set_color(&part.style.as_ref().unwrap().render_style_to_color_spec())?;

--- a/kclvm/compiler_base/error/src/emitter.rs
+++ b/kclvm/compiler_base/error/src/emitter.rs
@@ -1,13 +1,13 @@
 //! 'emitter.rs' defines the diagnostic emitter,
 //! which is responsible for displaying the rendered diagnostic.
-//! 
+//!
 //! The crate providers `Emitter` trait to define the interface that diagnostic emitter should implement.
-//! and also provider a built-in emitters:
-//! 
+//! and also provide a built-in emitters:
+//!
 //!  + `TerminalEmitter` is responsible for emitting diagnostic to the terminal.
 //!  + TODO(zongz): `EmitterAPI` is responsible for serializing diagnostics and emitting them to the API.
-//! 
-//！Besides, it's easy define your customized `Emitter` by implementing `Emitter` trait.
+//!
+//！Besides, it's easy to define your customized `Emitter` by implementing `Emitter` trait.
 //! For more information about how to define your customized `Emitter`, see the doc above `Emitter` trait.
 //!
 use crate::diagnostic::{Component, Diagnostic};
@@ -97,9 +97,9 @@ where
     }
 }
 
-/// `TerminalEmitter` implements trait `Emitter` based on `termcolor1.0` 
+/// `TerminalEmitter` implements trait `Emitter` based on `termcolor1.0`
 /// for rendering diagnostic as strings and displaying them to the terminal.
-/// 
+///
 /// `termcolor1.0` supports displaying colorful string to terminal.
 ///
 /// # Examples

--- a/kclvm/compiler_base/error/src/emitter.rs
+++ b/kclvm/compiler_base/error/src/emitter.rs
@@ -1,8 +1,8 @@
 //! 'emitter.rs' defines the diagnostic emitter,
 //! which is responsible for displaying the rendered diagnostic.
 //!
-//! The crate providers `Emitter` trait to define the interface that diagnostic emitter should implement.
-//! and also provide a built-in emitters:
+//! The crate provides `Emitter` trait to define the interface that diagnostic emitter should implement.
+//! and also provides a built-in emitters:
 //!
 //!  + `TerminalEmitter` is responsible for emitting diagnostic to the terminal.
 //!  + TODO(zongz): `EmitterAPI` is responsible for serializing diagnostics and emitting them to the API.

--- a/kclvm/compiler_base/error/src/emitter.rs
+++ b/kclvm/compiler_base/error/src/emitter.rs
@@ -45,17 +45,8 @@ impl Default for EmitterWriter {
     }
 }
 
-impl EmitterWriter {
-    pub fn from_stderr() -> Self {
-        Self {
-            dst: Destination::from_stderr(),
-            short_message: false,
-        }
-    }
-}
-
 /// Emit destinations
-pub enum Destination {
+enum Destination {
     /// The `StandardStream` works similarly to `std::io::Stdout`,
     /// it is augmented with methods for coloring by the `WriteColor` trait.
     ///

--- a/kclvm/compiler_base/error/src/emitter.rs
+++ b/kclvm/compiler_base/error/src/emitter.rs
@@ -94,11 +94,11 @@ enum Destination {
 
 impl Destination {
     #[allow(dead_code)]
-    pub fn from_raw(dst: Box<dyn Write + Send>, colored: bool) -> Self {
+    fn from_raw(dst: Box<dyn Write + Send>, colored: bool) -> Self {
         Destination::Raw(dst, colored)
     }
 
-    pub fn from_stderr() -> Self {
+    fn from_stderr() -> Self {
         // On Windows we'll be performing global synchronization on the entire
         // system for emitting rustc errors, so there's no need to buffer
         // anything.

--- a/kclvm/compiler_base/error/src/emitter.rs
+++ b/kclvm/compiler_base/error/src/emitter.rs
@@ -7,7 +7,7 @@
 //! The builtin emitters currently provided in 'emitter.rs' are as follows:
 //!
 //! - `EmitterWriter` is responsible for rendering diagnostic as strings and displaying them to the terminal.
-//! - TODO(zongz): `EmitterAPI` is responsible for serializing diagnostic and sent them to the API.
+//! - TODO(zongz): `EmitterAPI` is responsible for serializing diagnostics and sent them to the API.
 //!
 use crate::diagnostic::{Component, Diagnostic};
 use compiler_base_macros::bug;
@@ -18,7 +18,7 @@ use rustc_errors::{
 use std::io::{self, Write};
 use termcolor::{Buffer, BufferWriter, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
-/// Emitter trait for emitting diagnostic.
+/// trait `Emitter` for emitting diagnostic.
 ///
 /// `T: Clone + PartialEq + Eq + Style` is responsible for the theme style when diaplaying diagnostic.
 /// Builtin `DiagnosticStyle` provided in 'compiler_base/error/diagnostic/style.rs'.
@@ -96,7 +96,9 @@ where
     }
 }
 
-/// `EmitterWriter` is a default concrete struct of trait `Emitter` based on `termcolor1.0`.
+/// `EmitterWriter` is a concrete struct of trait `Emitter` based on `termcolor1.0`.
+/// 
+/// It is responsible for rendering diagnostic as strings and displaying them to the terminal.
 /// `termcolor1.0` supports displaying colorful string to terminal.
 ///
 /// # Examples

--- a/kclvm/compiler_base/error/src/lib.rs
+++ b/kclvm/compiler_base/error/src/lib.rs
@@ -2,4 +2,4 @@ pub mod diagnostic;
 mod emitter;
 
 pub use emitter::Emitter;
-pub use emitter::EmitterWriter;
+pub use emitter::TerminalEmitter;

--- a/kclvm/compiler_base/error/src/lib.rs
+++ b/kclvm/compiler_base/error/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod diagnostic;
+pub mod emitter;

--- a/kclvm/compiler_base/error/src/lib.rs
+++ b/kclvm/compiler_base/error/src/lib.rs
@@ -1,5 +1,5 @@
-mod emitter;
 pub mod diagnostic;
+mod emitter;
 
 pub use emitter::Emitter;
 pub use emitter::EmitterWriter;

--- a/kclvm/compiler_base/error/src/lib.rs
+++ b/kclvm/compiler_base/error/src/lib.rs
@@ -1,2 +1,5 @@
+mod emitter;
 pub mod diagnostic;
-pub mod emitter;
+
+pub use emitter::Emitter;
+pub use emitter::EmitterWriter;


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 

issue #115

#### 2. What is the scope of this PR (e.g. component or file name):

compiler_base/error/emitter.rs

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [x] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

 deleted method `apply_style()`, `Style` provides method `render_style_to_color_spec()` to replace it.
Adapted trait `Emitter` for `Diagnostic` and `StyledBuffer`.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [x] Other

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
None
```
