### PR TITLE
Fix: Record used module

### DIFF
--- a/kclvm/sema/src/resolver/test_data/record_used_module.k
+++ b/kclvm/sema/src/resolver/test_data/record_used_module.k
@@ -6,13 +6,18 @@ import import_test.e
 import import_test.f as g
 import pkg
 import math
+import regex
 
 schema Main(d.Parent):
     mixin [c.TestOfMixin]
+    name?: str
     age?: int = 18
     person?: a.Person
     list_union_type: [e.UnionType|int]
-    dict_union_type: {g.UnionType|int:float} 
+    dict_union_type: {g.UnionType|int:float}
+
+    check:
+        regex.match(name, r"[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*") if name
 
 if a._a > 1:
     _c = 1

--- a/kclvm/sema/src/resolver/var.rs
+++ b/kclvm/sema/src/resolver/var.rs
@@ -84,9 +84,10 @@ impl<'ctx> Resolver<'ctx> {
                 }
             }
         } else {
+            // lookup pkgpath scope and record it as "used"
             if !pkgpath.is_empty() {
-                if let Some(module_scope) = self.scope.borrow_mut().elems.get_mut(pkgpath) {
-                    module_scope.borrow_mut().used = true;
+                if let Some(obj) = self.scope.borrow().lookup(pkgpath) {
+                    obj.borrow_mut().used = true;
                 }
             }
             // Load type

--- a/kclvm/sema/src/resolver/var.rs
+++ b/kclvm/sema/src/resolver/var.rs
@@ -84,7 +84,8 @@ impl<'ctx> Resolver<'ctx> {
                 }
             }
         } else {
-            // lookup pkgpath scope and record it as "used"
+            // Lookup pkgpath scope object and record it as "used". When enter child scope, e.g., in a schema scope, cant find module object.
+            // It should be recursively search whole scope to lookup scope object, not the current scope.element.
             if !pkgpath.is_empty() {
                 if let Some(obj) = self.scope.borrow().lookup(pkgpath) {
                     obj.borrow_mut().used = true;


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y fix #132 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):
sema/resolver/var.rs

<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kusionstack/KCLVM/kclvm-parser 
-->

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

Fix bug in resolve_var(). When enter child scope,  e.g., in a schema scope, cant find module object.
It should be  recursively search whole scope to lookup module object, not the current scope.element.

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
None
```
