### PR TITLE
Kclvm capi call

### DIFF
--- a/internal/kclvm_py/program/rpc-server/__main__.py
+++ b/internal/kclvm_py/program/rpc-server/__main__.py
@@ -1,6 +1,5 @@
 # Copyright 2021 The KCL Authors. All rights reserved.
 
-import io
 import json
 import sys
 import socket
@@ -8,10 +7,8 @@ import subprocess
 import typing
 import time
 import pathlib
-import ruamel.yaml as yaml
 
 from dataclasses import dataclass
-from collections import OrderedDict
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import kclvm.kcl.ast as ast
@@ -33,7 +30,6 @@ from kclvm.tools.validation import validate_code_with_attr_data
 from kclvm.tools.langserver import grpc_wrapper
 from kclvm.tools.printer import SchemaRuleCodeSnippet, splice_schema_with_rule
 from kclvm.tools.list_attribute.schema import get_schema_type_from_code
-from kclvm.vm.planner.plan import order_dict
 
 import kclvm.kcl.error.kcl_err_template as kcl_err_template
 
@@ -128,6 +124,23 @@ class KclvmServiceImpl(pbrpc.KclvmService):
         cmd_args: typing.List[ast.CmdArgSpec] = []
         cmd_overrides: typing.List[ast.CmdOverrideSpec] = []
 
+        # kcl -D name=value main.k
+        for x in args.args:
+            cmd_args.append(ast.CmdArgSpec(name=x.name, value=x.value))
+
+        # kcl main.k -O pkgpath:path.to.field=field_value
+        for x in args.overrides:
+            cmd_overrides.append(
+                ast.CmdOverrideSpec(
+                    pkgpath=x.pkgpath or "__main__",
+                    field_path=x.field_path,
+                    field_value=x.field_value,
+                    action=ast.OverrideAction(x.action)
+                    if x.action
+                    else ast.OverrideAction.CREATE_OR_UPDATE,
+                )
+            )
+
         work_dir: str = args.work_dir
         k_filename_list: typing.List[str] = list(args.k_filename_list)
         k_filename_list = [
@@ -154,64 +167,48 @@ class KclvmServiceImpl(pbrpc.KclvmService):
         sort_keys: bool = args.sort_keys
         include_schema_type_path: bool = args.include_schema_type_path
 
-        cli_args = [
-            "kcl",
-            "--target",
-            "native",
-        ] + k_filename_list or []
-
-        # kcl -D name=value main.k
-        for x in args.args:
-            cli_args += ["-D", x.name + "=" + x.value]
-
-        # kcl main.k -O pkgpath:path.to.field=field_value
-        for x in args.overrides:
-            cli_args += [
-                "-O",
-                (x.pkgpath or "__main__") + ":" + x.field_path + "=" + x.field_value,
-            ]
-
-        if disable_none:
-            cli_args += ["-n"]
-        if sort_keys:
-            cli_args += ["--sort"]
-
         start_time = time.time()
-
-        proc = subprocess.run(cli_args, capture_output=True, text=True, cwd=work_dir)
-        stdout = str(proc.stdout or "")
-        stderr = str(proc.stderr or "").strip()
-
-        if proc.returncode != 0:
-            if stdout and stderr:
-                raise Exception(f"stdout: {stdout}, stderr: {stderr}")
-            else:
-                kcl_error.report_exception(
-                    err_type=kcl_error.ErrType.CompileError_TYPE,
-                    arg_msg=stderr,
-                )
-
+        kcl_result = kclvm_exec.Run(
+            k_filename_list,
+            work_dir=work_dir,
+            k_code_list=k_code_list,
+            cmd_args=cmd_args,
+            cmd_overrides=cmd_overrides,
+            print_override_ast=print_override_ast,
+            strict_range_check=strict_range_check,
+            disable_none=disable_none,
+            verbose=verbose,
+            debug=debug,
+        )
         end_time = time.time()
 
         result = pb2.ExecProgram_Result()
 
         result.escaped_time = f"{end_time-start_time}"
 
-        results = list(yaml.safe_load_all(stdout))
-
-        output_json = (
-            json.dumps(
-                results,
-                default=lambda o: o.__dict__,
-                indent=4,
-            )
-            if results
-            else ""
+        # json
+        output_json = planner.JSONPlanner(
+            sort_keys=sort_keys, include_schema_type_path=include_schema_type_path
+        ).plan(
+            kcl_result.filter_by_path_selector(
+                to_kcl=not kclvm.config.is_target_native
+            ),
+            to_py=not kclvm.config.is_target_native,
         )
-
         result.json_result = output_json
+
+        # yaml
         if not disable_yaml_result:
-            result.yaml_result = stdout
+            output_yaml = planner.YAMLPlanner(
+                sort_keys=sort_keys, include_schema_type_path=include_schema_type_path
+            ).plan(
+                kcl_result.filter_by_path_selector(
+                    to_kcl=not kclvm.config.is_target_native
+                ),
+                to_py=not kclvm.config.is_target_native,
+            )
+            result.yaml_result = output_yaml
+
         return result
 
     def ResetPlugin(self, args: pb2.ResetPlugin_Args) -> pb2.ResetPlugin_Result:

--- a/kclvm/parser/src/lib.rs
+++ b/kclvm/parser/src/lib.rs
@@ -109,11 +109,12 @@ pub fn parse_expr(src: &str) -> Option<ast::NodeRef<ast::Expr>> {
         sm.new_source_file(PathBuf::from("").into(), src.to_string());
         let sess = &ParseSession::with_source_map(Arc::new(sm));
 
-        Some(create_session_globals_then(|| {
+        let expr: Option<ast::NodeRef<ast::Expr>> = Some(create_session_globals_then(|| {
             let stream = parse_token_streams(sess, src, BytePos::from_u32(0));
             let mut parser = Parser::new(sess, stream);
             parser.parse_expr()
-        }))
+        }));
+        expr
     }
 }
 

--- a/kclvm/runner/src/assembler.rs
+++ b/kclvm/runner/src/assembler.rs
@@ -88,7 +88,8 @@ pub(crate) trait LibAssembler {
         let lib_path = format!("{}{}", code_file, Command::get_lib_suffix());
 
         // Locking file for parallel code generation.
-        let mut file_lock = fslock::LockFile::open(lock_file_path).unwrap();
+        let mut file_lock =
+            fslock::LockFile::open(lock_file_path).expect(&format!("{} not found", lock_file_path));
         file_lock.lock().unwrap();
 
         // Calling the hook method will generate the corresponding intermediate code

--- a/kclvm/runner/src/command.rs
+++ b/kclvm/runner/src/command.rs
@@ -172,14 +172,18 @@ impl Command {
         ];
         args.append(&mut more_args);
 
-        std::process::Command::new(self.clang_path.clone())
+        let output = std::process::Command::new(self.clang_path.clone())
             .stdout(std::process::Stdio::inherit())
             .stderr(std::process::Stdio::inherit())
             .args(&args)
             .output()
             .expect("clang failed");
+
         // Use absolute path.
-        let path = PathBuf::from(&lib_path).canonicalize().unwrap();
+        let path = PathBuf::from(&lib_path).canonicalize().expect(&format!(
+            "{} not found; assembly info: {:?}",
+            lib_path, output
+        ));
         path.to_str().unwrap().to_string()
     }
 
@@ -208,7 +212,7 @@ impl Command {
         let txt_path = std::path::Path::new(&executable_root)
             .join(if Self::is_windows() { "libs" } else { "lib" })
             .join("rust-libstd-name.txt");
-        let rust_libstd_name = std::fs::read_to_string(txt_path).unwrap();
+        let rust_libstd_name = std::fs::read_to_string(txt_path).expect("rust libstd not found");
         let rust_libstd_name = rust_libstd_name.trim();
         format!("{}/lib/{}", executable_root, rust_libstd_name)
     }

--- a/kclvm/runner/src/lib.rs
+++ b/kclvm/runner/src/lib.rs
@@ -114,7 +114,7 @@ fn clean_tmp_files(temp_entry_file: &String, lib_suffix: &String) {
 #[inline]
 fn remove_file(file: &str) {
     if Path::new(&file).exists() {
-        std::fs::remove_file(&file).unwrap();
+        std::fs::remove_file(&file).expect(&format!("{} not found", file));
     }
 }
 
@@ -123,6 +123,6 @@ fn temp_file(dir: &str) -> String {
     let timestamp = chrono::Local::now().timestamp_nanos();
     let id = std::process::id();
     let file = format!("{}_{}", id, timestamp);
-    std::fs::create_dir_all(dir).unwrap();
+    std::fs::create_dir_all(dir).expect(&format!("{} not found", dir));
     Path::new(dir).join(file).to_str().unwrap().to_string()
 }

--- a/kclvm/runner/src/runner.rs
+++ b/kclvm/runner/src/runner.rs
@@ -113,8 +113,12 @@ pub struct KclvmRunner {
 impl KclvmRunner {
     pub fn new(lib_path: &str, opts: Option<KclvmRunnerOptions>) -> Self {
         let lib = unsafe {
-            libloading::Library::new(std::path::PathBuf::from(lib_path).canonicalize().unwrap())
-                .unwrap()
+            libloading::Library::new(
+                std::path::PathBuf::from(lib_path)
+                    .canonicalize()
+                    .expect(&format!("{} not found", lib_path)),
+            )
+            .unwrap()
         };
         Self {
             opts: opts.unwrap_or_default(),

--- a/kclvm/tools/src/query/tests.rs
+++ b/kclvm/tools/src/query/tests.rs
@@ -8,7 +8,7 @@ use pretty_assertions::assert_eq;
 #[test]
 fn test_override_file_simple() {
     let specs = vec![
-        "config.image=\"image/image\"".to_string(),
+        "config.image=image/image".to_string(),
         ":config.image=\"image/image:v1\"".to_string(),
         ":config.data={id=1,value=\"override_value\"}".to_string(),
     ];
@@ -44,7 +44,7 @@ fn test_override_file_import_paths() {
 fn test_override_file_config() {
     let specs = vec![
         "appConfiguration.image=\"kcl/kcl:{}\".format(version)".to_string(),
-        "appConfiguration.mainContainer.name=\"override_name\"".to_string(),
+        "appConfiguration.mainContainer.name=override_name".to_string(),
         "appConfiguration.labels.key.key=\"override_value\"".to_string(),
         "appConfiguration.overQuota=False".to_string(),
         "appConfiguration.probe={periodSeconds=20}".to_string(),


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kusionstack/KCLVM/kclvm-parser 
-->
[internal/kclvm_py/program/rpc-server/__main__.py](https://github.com/KusionStack/KCLVM/compare/main...NeverRaR:kclvm-capi-call?expand=1#diff-d016e24205d8f09eb8adadb518be3e03f5d7aa1fd5ba603d4985ec62d93f2742)
[kclvm/parser/src/lib.rs](https://github.com/KusionStack/KCLVM/compare/main...NeverRaR:kclvm-capi-call?expand=1#diff-ba434fced40c597ac8bd41c95c419fab357d264146faa07df7c13705cb07b7a0)
[kclvm/runner/](https://github.com/KusionStack/KCLVM/compare/main...NeverRaR:kclvm-capi-call?expand=1#diff-acc0da0c19c5067b64957a333489d0861dc38db6e6043fb9434eb308e16c78c5)
[kclvm/tools/src/query/](https://github.com/KusionStack/KCLVM/compare/main...NeverRaR:kclvm-capi-call?expand=1#diff-acea289240767340d5c908ae46b3c58d6a75262c74e16bfb9895fb66bc31a92a)

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->
[refactor: enhance kclvm runner error message.](https://github.com/KusionStack/KCLVM/commit/08798f9cac220126f6b9d50a707c2a2dab7ab687)
[chore: kclvm python server use kclvm dylib to run.](https://github.com/KusionStack/KCLVM/commit/bd4d001d81578ab694a46260656da9688cf2c2a1)
[feat: sync python override api in rust](https://github.com/KusionStack/KCLVM/commit/11f822634d98e3e1e1855630171021743a1a4eb7)

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other
[kclvm/tools/src/query/tests.rs](https://github.com/KusionStack/KCLVM/compare/main...NeverRaR:kclvm-capi-call?expand=1#diff-24019c75a9b98901f661d017e525b31a7ef8d3c3d4ef509b488851f3ac9aef94)
<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
None
```
