### PR TITLE
Fix(compiler_base): fix file path bug in `DiagnosticHandler::default()`.

### DIFF
--- a/compiler_base/error/src/diagnostic/diagnostic_handler.rs
+++ b/compiler_base/error/src/diagnostic/diagnostic_handler.rs
@@ -16,10 +16,11 @@ use crate::{
 use anyhow::{bail, Context, Result};
 use compiler_base_span::fatal_error::FatalError;
 use fluent::FluentArgs;
-use std::sync::{Arc, Mutex};
+use std::{sync::{Arc, Mutex}, path::PathBuf};
 
 // Default template resource file path.
-const DEFAULT_TEMPLATE_RESOURCE: &str = "./src/diagnostic/locales/en-US/";
+const DEFAULT_TEMPLATE_RESOURCE: &str = "src/diagnostic/locales/en-US/";
+const DIAGNOSTIC_MESSAGES_ROOT: &str = env!("CARGO_MANIFEST_DIR");
 
 /// `DiagnosticHandler` supports diagnostic messages to terminal stderr.
 ///
@@ -95,7 +96,16 @@ impl DiagnosticHandler {
     /// Call the constructor 'new_with_template_dir()' to load the file.
     /// For more information about the constructor 'new_with_template_dir()', see the doc above 'new_with_template_dir()'.
     pub fn default() -> Result<Self> {
-        DiagnosticHandler::new_with_template_dir(DEFAULT_TEMPLATE_RESOURCE).with_context(|| {
+        let mut cargo_file_path = PathBuf::from(DIAGNOSTIC_MESSAGES_ROOT);
+        cargo_file_path.push(DEFAULT_TEMPLATE_RESOURCE);
+        let abs_path = cargo_file_path.to_str().with_context(|| {
+            format!(
+                "No such file or directory '{}'",
+                DEFAULT_TEMPLATE_RESOURCE
+            )
+        })?;
+
+        DiagnosticHandler::new_with_template_dir(abs_path).with_context(|| {
             format!(
                 "Failed to init `TemplateLoader` from '{}'",
                 DEFAULT_TEMPLATE_RESOURCE


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 

issue #115

#### 2. What is the scope of this PR (e.g. component or file name):

compiler_base

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [x] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

The relative path in method `DiagnosticHandler::default()` will cause file-not-found error. Fixed by replacing relative path with abs path.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other


#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
None
```
