### PR TITLE
Feat(compiler-base-span): add util functions for compiler-base-span.

### DIFF
--- a/compiler_base/span/Cargo.toml
+++ b/compiler_base/span/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiler_base_span"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 authors = ["zongzhe1024@163.com"]
 license = "Apache-2.0 OR MIT"

--- a/compiler_base/span/src/lib.rs
+++ b/compiler_base/span/src/lib.rs
@@ -9,12 +9,26 @@
 
 pub mod span;
 pub use rustc_span::fatal_error;
+use span::new_byte_pos;
 pub use span::{BytePos, Span, SpanData, DUMMY_SP};
 
 pub type SourceMap = rustc_span::SourceMap;
 pub type SourceFile = rustc_span::SourceFile;
 pub type FilePathMapping = rustc_span::source_map::FilePathMapping;
 pub type Loc = rustc_span::Loc;
+
+/// New a `Span`.
+///
+/// # Examples
+///
+/// ```
+/// use compiler_base_span::new_span;
+/// let span = new_span(0, 0);
+/// ```
+#[inline]
+pub fn new_span(lo: u32, hi: u32) -> Span {
+    Span::new(new_byte_pos(lo), new_byte_pos(hi))
+}
 
 /// Get the filename from `SourceMap` by `Span`.
 ///
@@ -44,4 +58,215 @@ pub type Loc = rustc_span::Loc;
 #[inline]
 pub fn span_to_filename_string(span: &Span, sm: &SourceMap) -> String {
     format!("{}", sm.span_to_filename(*span).prefer_remapped())
+}
+
+/// Get the position information from `SourceMap` by `Span`.
+///
+/// # Examples
+///
+/// ```rust
+/// # use compiler_base_span::{span_to_filename_string, span::new_byte_pos, FilePathMapping, SourceMap};
+/// # use compiler_base_span::span_to_position_info;
+/// # use rustc_span::SpanData;
+/// # use std::path::PathBuf;
+/// # use std::fs;
+///
+/// // 1. You need to hold a `SourceMap` at first.
+/// const CARGO_ROOT: &str = env!("CARGO_MANIFEST_DIR");
+/// let mut cargo_file_path = PathBuf::from(CARGO_ROOT);
+/// cargo_file_path.push("src/test_datas/code_snippet");
+/// let filename = cargo_file_path.to_str().unwrap();
+
+/// let src = std::fs::read_to_string(filename.clone()).unwrap();
+/// let sm = SourceMap::new(FilePathMapping::empty());
+/// sm.new_source_file(PathBuf::from(filename.clone()).into(), src);
+///
+/// // 2. You got the span in `SourceMap`.
+/// let span = SpanData {
+///     lo: new_byte_pos(10),
+///     hi: new_byte_pos(50),
+/// }.span();
+///
+/// // 3. You can got the position information by `span_to_position_info()`.
+/// assert_eq!(span_to_position_info(&span, &sm), format!("{}{}", filename, ":1:11: 2:30"));
+/// ```
+#[inline]
+pub fn span_to_position_info(span: &Span, sm: &SourceMap) -> String {
+    sm.span_to_diagnostic_string(*span)
+}
+
+/// Get the position start line from `SourceMap` by `Span`.
+///
+/// # Examples
+///
+/// ```rust
+/// # use compiler_base_span::{span_to_filename_string, span::new_byte_pos, FilePathMapping, SourceMap};
+/// # use compiler_base_span::span_to_start_line;
+/// # use rustc_span::SpanData;
+/// # use std::path::PathBuf;
+/// # use std::fs;
+///
+/// // 1. You need to hold a `SourceMap` at first.
+/// const CARGO_ROOT: &str = env!("CARGO_MANIFEST_DIR");
+/// let mut cargo_file_path = PathBuf::from(CARGO_ROOT);
+/// cargo_file_path.push("src/test_datas/code_snippet");
+/// let filename = cargo_file_path.to_str().unwrap();
+
+/// let src = std::fs::read_to_string(filename.clone()).unwrap();
+/// let sm = SourceMap::new(FilePathMapping::empty());
+/// sm.new_source_file(PathBuf::from(filename.clone()).into(), src);
+///
+/// // 2. You got the span in `SourceMap`.
+/// let span = SpanData {
+///     lo: new_byte_pos(10),
+///     hi: new_byte_pos(50),
+/// }.span();
+///
+/// // 3. You can got the position information by `span_to_start_line()`.
+/// assert_eq!(span_to_start_line(&span, &sm), 1);
+/// ```
+#[inline]
+pub fn span_to_start_line(span: &Span, sm: &SourceMap) -> usize {
+    sm.lookup_char_pos(span.lo()).line
+}
+
+/// Get the position start column from `SourceMap` by `Span`.
+///
+/// # Examples
+///
+/// ```rust
+/// # use compiler_base_span::{span_to_filename_string, span::new_byte_pos, FilePathMapping, SourceMap};
+/// # use compiler_base_span::span_to_start_column;
+/// # use rustc_span::SpanData;
+/// # use std::path::PathBuf;
+/// # use std::fs;
+///
+/// // 1. You need to hold a `SourceMap` at first.
+/// const CARGO_ROOT: &str = env!("CARGO_MANIFEST_DIR");
+/// let mut cargo_file_path = PathBuf::from(CARGO_ROOT);
+/// cargo_file_path.push("src/test_datas/code_snippet");
+/// let filename = cargo_file_path.to_str().unwrap();
+
+/// let src = std::fs::read_to_string(filename.clone()).unwrap();
+/// let sm = SourceMap::new(FilePathMapping::empty());
+/// sm.new_source_file(PathBuf::from(filename.clone()).into(), src);
+///
+/// // 2. You got the span in `SourceMap`.
+/// let span = SpanData {
+///     lo: new_byte_pos(10),
+///     hi: new_byte_pos(50),
+/// }.span();
+///
+/// // 3. You can got the position information by `span_to_start_column()`.
+/// assert_eq!(span_to_start_column(&span, &sm), 11);
+/// ```
+#[inline]
+pub fn span_to_start_column(span: &Span, sm: &SourceMap) -> usize {
+    sm.lookup_char_pos(span.lo()).col_display + 1
+}
+
+/// Get the position end line from `SourceMap` by `Span`.
+///
+/// # Examples
+///
+/// ```rust
+/// # use compiler_base_span::{span_to_filename_string, span::new_byte_pos, FilePathMapping, SourceMap};
+/// # use compiler_base_span::span_to_end_line;
+/// # use rustc_span::SpanData;
+/// # use std::path::PathBuf;
+/// # use std::fs;
+///
+/// // 1. You need to hold a `SourceMap` at first.
+/// const CARGO_ROOT: &str = env!("CARGO_MANIFEST_DIR");
+/// let mut cargo_file_path = PathBuf::from(CARGO_ROOT);
+/// cargo_file_path.push("src/test_datas/code_snippet");
+/// let filename = cargo_file_path.to_str().unwrap();
+
+/// let src = std::fs::read_to_string(filename.clone()).unwrap();
+/// let sm = SourceMap::new(FilePathMapping::empty());
+/// sm.new_source_file(PathBuf::from(filename.clone()).into(), src);
+///
+/// // 2. You got the span in `SourceMap`.
+/// let span = SpanData {
+///     lo: new_byte_pos(10),
+///     hi: new_byte_pos(50),
+/// }.span();
+///
+/// // 3. You can got the position information by `span_to_end_line()`.
+/// assert_eq!(span_to_end_line(&span, &sm), 2);
+/// ```
+#[inline]
+pub fn span_to_end_line(span: &Span, sm: &SourceMap) -> usize {
+    sm.lookup_char_pos(span.hi()).line
+}
+
+/// Get the position end column from `SourceMap` by `Span`.
+///
+/// # Examples
+///
+/// ```rust
+/// # use compiler_base_span::{span_to_filename_string, span::new_byte_pos, FilePathMapping, SourceMap};
+/// # use compiler_base_span::span_to_end_column;
+/// # use rustc_span::SpanData;
+/// # use std::path::PathBuf;
+/// # use std::fs;
+///
+/// // 1. You need to hold a `SourceMap` at first.
+/// const CARGO_ROOT: &str = env!("CARGO_MANIFEST_DIR");
+/// let mut cargo_file_path = PathBuf::from(CARGO_ROOT);
+/// cargo_file_path.push("src/test_datas/code_snippet");
+/// let filename = cargo_file_path.to_str().unwrap();
+
+/// let src = std::fs::read_to_string(filename.clone()).unwrap();
+/// let sm = SourceMap::new(FilePathMapping::empty());
+/// sm.new_source_file(PathBuf::from(filename.clone()).into(), src);
+///
+/// // 2. You got the span in `SourceMap`.
+/// let span = SpanData {
+///     lo: new_byte_pos(10),
+///     hi: new_byte_pos(50),
+/// }.span();
+///
+/// // 3. You can got the position information by `span_to_end_column()`.
+/// assert_eq!(span_to_end_column(&span, &sm), 30);
+/// ```
+#[inline]
+pub fn span_to_end_column(span: &Span, sm: &SourceMap) -> usize {
+    sm.lookup_char_pos(span.hi()).col_display + 1
+}
+
+#[cfg(test)]
+mod test {
+    use std::path::PathBuf;
+
+    use crate::{
+        span::new_byte_pos, span_to_end_column, span_to_end_line, span_to_position_info,
+        span_to_start_column, span_to_start_line, FilePathMapping, SourceMap, Span,
+    };
+
+    const CARGO_ROOT: &str = env!("CARGO_MANIFEST_DIR");
+
+    #[test]
+    fn test_span_util_functions() {
+        let mut cargo_file_path = PathBuf::from(CARGO_ROOT);
+        cargo_file_path.push("src/test_datas/code_snippet");
+        let full_path = cargo_file_path.to_str().unwrap();
+
+        let src = std::fs::read_to_string(full_path.clone()).unwrap();
+        let sm = SourceMap::new(FilePathMapping::empty());
+        sm.new_source_file(PathBuf::from(full_path.clone()).into(), src);
+
+        let span = Span::new(new_byte_pos(10), new_byte_pos(50));
+
+        assert_eq!(span_to_start_line(&span, &sm), 1);
+        assert_eq!(span_to_end_line(&span, &sm), 2);
+
+        assert_eq!(span_to_start_column(&span, &sm), 11);
+        assert_eq!(span_to_end_column(&span, &sm), 30);
+
+        assert_eq!(
+            span_to_position_info(&span, &sm),
+            format!("{}{}", full_path, ":1:11: 2:30")
+        );
+    }
 }


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 

issue #115.

#### 2. What is the scope of this PR (e.g. component or file name):

compiler_base_span

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [x] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

add function `new_span` to construct a new `Span`.
add function `span_to_position_info` to get the position information from `SourceMap` by `Span`.
add function `span_to_start_line` to get the position start line from `SourceMap` by `Span`.
add function `span_to_start_column` to get the position start column from `SourceMap` by `Span`.
add function `span_to_end_line` to get the position end line from `SourceMap` by `Span`.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
None
```
