### PR TITLE
Fix(kclvm-parser): return loading file failed error message from meth…

### DIFF
--- a/kclvm/parser/src/lib.rs
+++ b/kclvm/parser/src/lib.rs
@@ -70,7 +70,14 @@ pub fn parse_file(filename: &str, code: Option<String>) -> Result<ast::Module, S
         let src = if let Some(s) = code {
             s
         } else {
-            std::fs::read_to_string(filename).unwrap()
+            match std::fs::read_to_string(filename) {
+                Ok(src) => src,
+                Err(_err) => {
+                    let err_msg =
+                        format!("Failed to load KCL file '{}'. Because '{}'", filename, _err);
+                    return Err(err_msg);
+                }
+            }
         };
 
         let sm = kclvm_span::SourceMap::new(FilePathMapping::empty());

--- a/kclvm/parser/src/parser/tests.rs
+++ b/kclvm/parser/src/parser/tests.rs
@@ -1,4 +1,5 @@
 use crate::lexer::parse_token_streams;
+use crate::parse_file;
 use crate::parser::Parser;
 use crate::session::ParseSession;
 use expect_test::{expect, Expect};
@@ -1265,4 +1266,16 @@ fn smoke_test_parsing_stmt() {
 
         assert_eq!(got, expect);
     });
+}
+
+#[test]
+fn test_parse_file_not_found() {
+    match parse_file("The file path is invalid", None) {
+        Ok(_) => {
+            panic!("unreachable")
+        }
+        Err(err_msg) => {
+            assert_eq!(err_msg, "Failed to load KCL file 'The file path is invalid'. Because 'No such file or directory (os error 2)'");
+        }
+    }
 }


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 

issue #236

#### 2. What is the scope of this PR (e.g. component or file name):

kclvm-parser

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

Use `match` replace `unwrap`.
And the error of loading the file is returned by the return value.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
None
```
