### PR TITLE
Fix(compiler-base-error): `CodeSnippet` component generates the line …

### DIFF
--- a/compiler_base/3rdparty/rustc_errors/src/styled_buffer.rs
+++ b/compiler_base/3rdparty/rustc_errors/src/styled_buffer.rs
@@ -34,9 +34,9 @@ where
     T: Clone + PartialEq + Eq + Style,
 {
     /// Constructs a new `StyledString` by string and style.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```ignore
     /// // You need to choose a style for the generic parameter `T` of `StyledString`.
     /// #[derive(Clone, PartialEq, Eq)]
@@ -46,7 +46,7 @@ where
     /// impl Style for MyStyle {
     ///     ...
     /// }
-    /// 
+    ///
     /// let styled_string = StyledString::<MyStyle>::new("Hello Styled String".to_string(), Some<MyStyle::Style_1>);
     /// ```
     #[inline]

--- a/compiler_base/error/src/diagnostic/components.rs
+++ b/compiler_base/error/src/diagnostic/components.rs
@@ -351,7 +351,7 @@ impl Component<DiagnosticStyle> for CodeSnippet {
                     )) {
                     Some(sf) => {
                         for line in affected_lines.lines {
-                            let line_index = line.line_index.to_string();
+                            let line_index = (line.line_index + 1).to_string();
                             let indent = line_index.len() + 1;
                             IndentWithPrefix::new(line_index, indent, Some(DiagnosticStyle::Url))
                                 .format(sb, errs);

--- a/compiler_base/error/src/diagnostic/tests.rs
+++ b/compiler_base/error/src/diagnostic/tests.rs
@@ -136,8 +136,8 @@ mod test_components {
         sm.new_source_file(PathBuf::from(filename.clone()).into(), src);
 
         let code_span = SpanData {
-            lo: new_byte_pos(23),
-            hi: new_byte_pos(25),
+            lo: new_byte_pos(0),
+            hi: new_byte_pos(5),
         }
         .span();
 
@@ -155,15 +155,15 @@ mod test_components {
         assert_eq!(errs.len(), 0);
         assert_eq!(result.len(), 1);
         assert_eq!(result.get(0).unwrap().len(), 6);
-        let expected_path = format!("---> File: {}:2:3: 2:5", filename);
+        let expected_path = format!("---> File: {}:1:1: 1:6", filename);
         assert_eq!(result.get(0).unwrap().get(0).unwrap().text, expected_path);
         assert_eq!(result.get(0).unwrap().get(1).unwrap().text, "\n  ");
         assert_eq!(result.get(0).unwrap().get(2).unwrap().text, "1");
         assert_eq!(
             result.get(0).unwrap().get(3).unwrap().text,
-            "|Line 2 Code Snippet.\n   |  "
+            "|Line 1 Code Snippet.\n   |"
         );
-        assert_eq!(result.get(0).unwrap().get(4).unwrap().text, "^^");
+        assert_eq!(result.get(0).unwrap().get(4).unwrap().text, "^^^^^");
         assert_eq!(result.get(0).unwrap().get(5).unwrap().text, "\n");
     }
 }


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 

issue #115

#### 2. What is the scope of this PR (e.g. component or file name):

compiler_base_error

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [x] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

In `CodeSnippet` components, the line number plus one.

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
None
```
