### PR TITLE
Feat(compiler-base-error): remove the newline at the end of component…

### DIFF
--- a/compiler_base/error/src/diagnostic/components.rs
+++ b/compiler_base/error/src/diagnostic/components.rs
@@ -376,7 +376,9 @@ impl Component<DiagnosticStyle> for CodeSnippet {
                                 Some(DiagnosticStyle::NeedFix),
                             )
                             .format(sb, errs);
-                            sb.appendl("\n", None);
+                            // The newline "\n" should not be included at the end of the `CodeSnippet`.
+                            // The user can choose whether to add a newline at the end of `CodeSnippet` instead of
+                            // having the newline built in at the end of `CodeSnippet`.
                         }
                     }
                     None => errs.push(ComponentFormatError::new(

--- a/compiler_base/error/src/diagnostic/tests.rs
+++ b/compiler_base/error/src/diagnostic/tests.rs
@@ -154,7 +154,7 @@ mod test_components {
 
         assert_eq!(errs.len(), 0);
         assert_eq!(result.len(), 1);
-        assert_eq!(result.get(0).unwrap().len(), 6);
+        assert_eq!(result.get(0).unwrap().len(), 5);
         let expected_path = format!("---> File: {}:1:1: 1:6", filename);
         assert_eq!(result.get(0).unwrap().get(0).unwrap().text, expected_path);
         assert_eq!(result.get(0).unwrap().get(1).unwrap().text, "\n  ");
@@ -164,7 +164,6 @@ mod test_components {
             "|Line 1 Code Snippet.\n   |"
         );
         assert_eq!(result.get(0).unwrap().get(4).unwrap().text, "^^^^^");
-        assert_eq!(result.get(0).unwrap().get(5).unwrap().text, "\n");
     }
 }
 


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 

issue #115

#### 2. What is the scope of this PR (e.g. component or file name):

compiler_base_error

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [x] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

remove the newline at the end of component `CodeSnippet`.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
None
```
