### PR TITLE
Feat(rustc_error): add trait Debug, PartialEq, Eq for StyledBuffer, StyledString and StyledChar

### DIFF
--- a/compiler_base/3rdparty/rustc_errors/Cargo.toml
+++ b/compiler_base/3rdparty/rustc_errors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustc_errors"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 authors = ["zongzhe1024@163.com"]
 license = "Apache-2.0 OR MIT"

--- a/compiler_base/3rdparty/rustc_errors/src/styled_buffer.rs
+++ b/compiler_base/3rdparty/rustc_errors/src/styled_buffer.rs
@@ -4,6 +4,7 @@
 use crate::Style;
 
 /// An acceptable custom `XXXStyle` for `StyledBuffer` must implement trait `Clone`, `PartialEq`, `Eq` and `Style`.
+#[derive(Debug, PartialEq, Eq)]
 pub struct StyledBuffer<T>
 where
     T: Clone + PartialEq + Eq + Style,
@@ -11,7 +12,7 @@ where
     lines: Vec<Vec<StyledChar<T>>>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 struct StyledChar<T>
 where
     T: Clone + PartialEq + Eq + Style,
@@ -21,6 +22,7 @@ where
 }
 
 /// An acceptable custom `XXXStyle` for `StyledString` must implement trait `Clone`, `PartialEq`, `Eq` and `Style`.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StyledString<T>
 where
     T: Clone + PartialEq + Eq + Style,


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 

issue #115.

#### 2. What is the scope of this PR (e.g. component or file name):

rustc_error

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [x] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

add trait Debug, PartialEq, Eq for StyledBuffer, StyledString and StyledChar.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [x] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
None
```
