### PR TITLE
Feat(compiler-base-session): Add some methods for Session.

### DIFF
--- a/compiler_base/session/Cargo.toml
+++ b/compiler_base/session/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiler_base_session"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2021"
 authors = ["zongzhe1024@163.com"]
 license = "Apache-2.0 OR MIT"
@@ -15,5 +15,5 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 compiler_base_span = "0.0.1"
-compiler_base_error = "0.0.4"
+compiler_base_error = "0.0.5"
 anyhow = "1.0"

--- a/compiler_base/session/Cargo.toml
+++ b/compiler_base/session/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiler_base_session"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2021"
 authors = ["zongzhe1024@163.com"]
 license = "Apache-2.0 OR MIT"

--- a/compiler_base/session/src/lib.rs
+++ b/compiler_base/session/src/lib.rs
@@ -169,11 +169,12 @@ impl Session {
     /// });
     /// assert!(result.is_err());
     /// ```
-    pub fn emit_stashed_diagnostics_and_abort(&self) -> Result<bool> {
+    #[inline]
+    pub fn emit_stashed_diagnostics_and_abort(&self) -> Result<&Self> {
         self.diag_handler
             .abort_if_errors()
             .with_context(|| "Internale Bug: Fail to display error diagnostic")?;
-        Ok(true)
+        Ok(self)
     }
 
     /// Emit all diagnostics to terminal.

--- a/compiler_base/session/src/lib.rs
+++ b/compiler_base/session/src/lib.rs
@@ -128,11 +128,11 @@ impl Session {
         })
     }
 
-    /// Emit error diagnostic to terminal.
+    /// Emit all diagnostics to terminal and abort.
     ///
     /// # Panics
     ///
-    /// After emitting the error diagnositc, the program will panic.
+    /// After emitting the diagnositcs, the program will panic.
     ///
     /// # Examples
     ///
@@ -162,18 +162,175 @@ impl Session {
     /// let result = std::panic::catch_unwind(|| {
     ///    // 3. Create a Session.
     ///    let sess = Session::new_with_src_code("test code").unwrap();
-    ///    // 4. Emit the error diagnostic.
-    ///    sess.emit_err(MyError {}).unwrap();
+    ///    // 4. Add the error diagnostic.
+    ///    sess.add_err(MyError {}).unwrap();
+    ///    // 5. Emit the error diagnostic.
+    ///    sess.emit_stashed_diagnostics_and_abort().unwrap();
     /// });
     /// assert!(result.is_err());
-    ///
     /// ```
-    pub fn emit_err(&self, err: impl SessionDiagnostic) -> Result<bool> {
+    pub fn emit_stashed_diagnostics_and_abort(&self) -> Result<bool> {
         self.diag_handler
-            .add_err_diagnostic(err.into_diagnostic(self)?)?
             .abort_if_errors()
             .with_context(|| "Internale Bug: Fail to display error diagnostic")?;
         Ok(true)
+    }
+
+    /// Emit all diagnostics to terminal.
+    ///
+    /// # Examples
+    ///
+    /// If you want to emit an diagnostic.
+    /// ```rust
+    /// # use compiler_base_session::Session;
+    /// # use compiler_base_error::components::Label;
+    /// # use compiler_base_error::DiagnosticStyle;
+    /// # use compiler_base_error::Diagnostic;
+    /// # use compiler_base_session::SessionDiagnostic;
+    /// # use anyhow::Result;
+    ///
+    /// // 1. Create your own error type.
+    /// struct MyError;
+    ///
+    /// // 2. Implement trait `SessionDiagnostic` manually.
+    /// impl SessionDiagnostic for MyError {
+    ///     fn into_diagnostic(self, sess: &Session) -> Result<Diagnostic<DiagnosticStyle>> {
+    ///         let mut diag = Diagnostic::<DiagnosticStyle>::new();
+    ///         // 1. Label Component
+    ///         let label_component = Box::new(Label::Error("error".to_string()));
+    ///         diag.append_component(label_component);
+    ///         Ok(diag)
+    ///     }
+    /// }
+    /// // 3. Create a Session.
+    /// let sess = Session::new_with_src_code("test code").unwrap();
+    ///
+    /// // 4. Add the error
+    /// sess.add_err(MyError {}).unwrap();
+    ///
+    /// // 5. Emit the error diagnostic.
+    /// sess.emit_stashed_diagnostics().unwrap();
+    /// ```
+    pub fn emit_stashed_diagnostics(&self) -> Result<&Self> {
+        self.diag_handler
+            .emit_stashed_diagnostics()
+            .with_context(|| "Internale Bug: Fail to display error diagnostic")?;
+        Ok(self)
+    }
+
+    /// Add an error diagnostic generated from error to `Session`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use compiler_base_error::DiagnosticStyle;
+    /// # use compiler_base_error::diagnostic_handler::DiagnosticHandler;
+    /// # use compiler_base_error::Diagnostic;
+    /// # use compiler_base_error::components::Label;
+    /// # use compiler_base_session::Session;
+    /// # use compiler_base_session::SessionDiagnostic;
+    /// # use anyhow::Result;
+    ///
+    /// // 1. Create your own error type.
+    /// struct MyError;
+    ///
+    /// // 2. Implement trait `SessionDiagnostic` manually.
+    /// impl SessionDiagnostic for MyError {
+    ///     fn into_diagnostic(self, sess: &Session) -> Result<Diagnostic<DiagnosticStyle>> {
+    ///         let mut diag = Diagnostic::<DiagnosticStyle>::new();
+    ///         // 1. Label Component
+    ///         let label_component = Box::new(Label::Error("error".to_string()));
+    ///         diag.append_component(label_component);
+    ///         Ok(diag)
+    ///     }
+    /// }
+    ///
+    /// let sess = Session::new_with_src_code("test code").unwrap();
+    /// assert_eq!(sess.diagnostics_count().unwrap(), 0);
+    ///
+    /// sess.add_err(MyError{});
+    /// assert_eq!(sess.diagnostics_count().unwrap(), 1);
+    /// ```
+    pub fn add_err(&self, err: impl SessionDiagnostic) -> Result<&Self> {
+        self.diag_handler
+            .add_err_diagnostic(err.into_diagnostic(self)?)?;
+        Ok(self)
+    }
+
+    /// Add an warn diagnostic generated from warning to `Session`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use compiler_base_error::DiagnosticStyle;
+    /// # use compiler_base_error::diagnostic_handler::DiagnosticHandler;
+    /// # use compiler_base_error::Diagnostic;
+    /// # use compiler_base_error::components::Label;
+    /// # use compiler_base_session::Session;
+    /// # use compiler_base_session::SessionDiagnostic;
+    /// # use anyhow::Result;
+    ///
+    /// // 1. Create your own error type.
+    /// struct MyWarning;
+    ///
+    /// // 2. Implement trait `SessionDiagnostic` manually.
+    /// impl SessionDiagnostic for MyWarning {
+    ///     fn into_diagnostic(self, sess: &Session) -> Result<Diagnostic<DiagnosticStyle>> {
+    ///         let mut diag = Diagnostic::<DiagnosticStyle>::new();
+    ///         // 1. Label Component
+    ///         let label_component = Box::new(Label::Warning("warning".to_string()));
+    ///         diag.append_component(label_component);
+    ///         Ok(diag)
+    ///     }
+    /// }
+    ///
+    /// let sess = Session::new_with_src_code("test code").unwrap();
+    /// assert_eq!(sess.diagnostics_count().unwrap(), 0);
+    ///
+    /// sess.add_err(MyWarning{});
+    /// assert_eq!(sess.diagnostics_count().unwrap(), 1);
+    /// ```
+    pub fn add_warn(&self, warn: impl SessionDiagnostic) -> Result<&Self> {
+        self.diag_handler
+            .add_warn_diagnostic(warn.into_diagnostic(self)?)?;
+        Ok(self)
+    }
+
+    /// Get count of diagnostics in `DiagnosticHandler`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use compiler_base_error::DiagnosticStyle;
+    /// # use compiler_base_error::diagnostic_handler::DiagnosticHandler;
+    /// # use compiler_base_error::Diagnostic;
+    /// # use compiler_base_error::components::Label;
+    /// # use compiler_base_session::Session;
+    /// # use compiler_base_session::SessionDiagnostic;
+    /// # use anyhow::Result;
+    ///
+    /// // 1. Create your own error type.
+    /// struct MyWarning;
+    ///
+    /// // 2. Implement trait `SessionDiagnostic` manually.
+    /// impl SessionDiagnostic for MyWarning {
+    ///     fn into_diagnostic(self, sess: &Session) -> Result<Diagnostic<DiagnosticStyle>> {
+    ///         let mut diag = Diagnostic::<DiagnosticStyle>::new();
+    ///         // 1. Label Component
+    ///         let label_component = Box::new(Label::Warning("warning".to_string()));
+    ///         diag.append_component(label_component);
+    ///         Ok(diag)
+    ///     }
+    /// }
+    ///
+    /// let sess = Session::new_with_src_code("test code").unwrap();
+    /// assert_eq!(sess.diagnostics_count().unwrap(), 0);
+    ///
+    /// sess.add_err(MyWarning{});
+    /// assert_eq!(sess.diagnostics_count().unwrap(), 1);
+    #[inline]
+    pub fn diagnostics_count(&self) -> Result<usize> {
+        self.diag_handler.diagnostics_count()
     }
 }
 


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 

issue #115 

#### 2. What is the scope of this PR (e.g. component or file name):

compiler-base-session

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [x] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

The old Session provide 'emit_err' which will panic when the diagnostic information is emitted. This situation is very rare in actual usage scenarios, so this PR provides some interfaces for adding errors/warnings, emitting diagnostics, and aborting the program.

'emit_stashed_diagnostics_and_abort' to emit all the diagnostics and abort.
'emit_stashed_diagnostics' to emit all the diagnostics but not abort.
'add_err' to add error to diagnostics.
'add-warn' to add warning to diagnostics.
'diagnostic_count' to get the count of diagnostics.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
None
```
