### PR TITLE
refactor : use std::box to avoid unnecessary memory alloc

### DIFF
--- a/kclvm/runtime/src/api/kclvm.rs
+++ b/kclvm/runtime/src/api/kclvm.rs
@@ -199,12 +199,9 @@ impl ValueRef {
     }
 
     pub fn from_raw(&self) {
-        match &*self.rc {
-            //if value is a func,clear captured ValueRef to break circular reference
-            Value::func_value(val) => {
-                get_ref_mut(val).closure = ValueRef::none();
-            }
-            _ => {}
+        //if value is a func,clear captured ValueRef to break circular reference
+        if let Value::func_value(val) = &*self.rc {
+            get_ref_mut(val).closure = ValueRef::none();
         }
     }
 }
@@ -218,10 +215,10 @@ pub enum Value {
     int_value(i64),
     float_value(f64),
     str_value(String),
-    list_value(ListValue),
-    dict_value(DictValue),
-    schema_value(SchemaValue),
-    func_value(FuncValue),
+    list_value(Box<ListValue>),
+    dict_value(Box<DictValue>),
+    schema_value(Box<SchemaValue>),
+    func_value(Box<FuncValue>),
     unit_value(f64, i64, String), // (Real value, raw value, unit string)
 }
 

--- a/kclvm/runtime/src/stdlib/builtin.rs
+++ b/kclvm/runtime/src/stdlib/builtin.rs
@@ -120,7 +120,7 @@ impl ValueRef {
                 } else {
                     values.sort();
                 }
-                Self::from(Value::list_value(list))
+                Self::from(Value::list_value(Box::new(list)))
             }
             Value::list_value(_) => {
                 let mut list = self.deep_copy();
@@ -145,7 +145,7 @@ impl ValueRef {
                 } else {
                     values.sort();
                 }
-                Self::from(Value::list_value(list))
+                Self::from(Value::list_value(Box::new(list)))
             }
             _ => panic!("sorted only for str|list|dict type"),
         }

--- a/kclvm/runtime/src/value/api.rs
+++ b/kclvm/runtime/src/value/api.rs
@@ -240,7 +240,7 @@ pub extern "C" fn kclvm_value_ListN(
             list.values.push(v.clone());
         }
 
-        ValueRef::from(Value::list_value(list)).into_raw()
+        ValueRef::from(Value::list_value(Box::new(list))).into_raw()
     }
 }
 

--- a/kclvm/runtime/src/value/val.rs
+++ b/kclvm/runtime/src/value/val.rs
@@ -38,7 +38,7 @@ impl ValueRef {
                 list.values.push((**x).clone());
             }
         }
-        Self::from(Value::list_value(list))
+        Self::from(Value::list_value(Box::new(list)))
     }
 
     pub fn list_value(values: Option<&[Self]>) -> Self {
@@ -48,7 +48,7 @@ impl ValueRef {
                 list.values.push((*x).clone());
             }
         }
-        Self::from(Value::list_value(list))
+        Self::from(Value::list_value(Box::new(list)))
     }
 
     pub fn dict(values: Option<&[(&str, &Self)]>) -> Self {
@@ -58,12 +58,12 @@ impl ValueRef {
                 dict.values.insert(x.0.to_string(), (*x.1).clone());
             }
         }
-        Self::from(Value::dict_value(dict))
+        Self::from(Value::dict_value(Box::new(dict)))
     }
 
     pub fn schema() -> Self {
         let s: SchemaValue = Default::default();
-        Self::from(Value::schema_value(s))
+        Self::from(Value::schema_value(Box::new(s)))
     }
 
     pub fn func(
@@ -73,12 +73,12 @@ impl ValueRef {
         name: &str,
         runtime_type: &str,
     ) -> Self {
-        Self::from(Value::func_value(FuncValue {
+        Self::from(Value::func_value(Box::new(FuncValue {
             fn_ptr,
             check_fn_ptr,
             closure,
             external_name: name.to_string(),
             runtime_type: runtime_type.to_string(),
-        }))
+        })))
     }
 }

--- a/kclvm/runtime/src/value/val_bin.rs
+++ b/kclvm/runtime/src/value/val_bin.rs
@@ -167,7 +167,7 @@ impl ValueRef {
                         list.values.push(x.clone());
                     }
                 }
-                Self::from(Value::list_value(list))
+                Self::from(Value::list_value(Box::new(list)))
             }
             (Value::int_value(b), Value::list_value(a)) => {
                 let mut list = ListValue::default();
@@ -176,7 +176,7 @@ impl ValueRef {
                         list.values.push(x.clone());
                     }
                 }
-                Self::from(Value::list_value(list))
+                Self::from(Value::list_value(Box::new(list)))
             }
             _ => panic_unsupported_bin_op!("*", self.type_str(), x.type_str()),
         }

--- a/kclvm/runtime/src/value/val_clone.rs
+++ b/kclvm/runtime/src/value/val_clone.rs
@@ -14,13 +14,13 @@ impl ValueRef {
                 rc: Rc::new(Value::none),
             },
             Value::func_value(ref v) => ValueRef {
-                rc: Rc::new(Value::func_value(FuncValue {
+                rc: Rc::new(Value::func_value(Box::new(FuncValue {
                     fn_ptr: v.fn_ptr,
                     check_fn_ptr: v.check_fn_ptr,
                     closure: v.closure.deep_copy(),
                     external_name: v.external_name.clone(),
                     runtime_type: v.runtime_type.clone(),
-                })),
+                }))),
             },
             Value::bool_value(ref v) => ValueRef {
                 rc: Rc::new(Value::bool_value(*v)),
@@ -38,9 +38,9 @@ impl ValueRef {
                 rc: Rc::new(Value::str_value(v.to_string())),
             },
             Value::list_value(ref v) => ValueRef {
-                rc: Rc::new(Value::list_value(ListValue {
+                rc: Rc::new(Value::list_value(Box::new(ListValue {
                     values: v.values.iter().map(|x| x.deep_copy()).collect(),
-                })),
+                }))),
             },
             Value::dict_value(ref v) => {
                 let mut dict = DictValue::new(&[]);
@@ -81,12 +81,12 @@ impl ValueRef {
                     }
                 }
                 ValueRef {
-                    rc: Rc::new(Value::schema_value(SchemaValue {
+                    rc: Rc::new(Value::schema_value(Box::new(SchemaValue {
                         name: v.name.clone(),
                         pkgpath: v.pkgpath.clone(),
                         config: Rc::new(dict.as_dict_ref().clone()),
                         config_keys: v.config_keys.clone(),
-                    })),
+                    }))),
                 }
             }
         }

--- a/kclvm/runtime/src/value/val_dict.rs
+++ b/kclvm/runtime/src/value/val_dict.rs
@@ -8,7 +8,7 @@ impl DictValue {
         for x in values {
             dict.values.insert(x.0.to_string(), x.1.clone());
         }
-        ValueRef::from(Value::dict_value(dict))
+        ValueRef::from(Value::dict_value(Box::new(dict)))
     }
 
     pub fn get(&self, key: &ValueRef) -> Option<&ValueRef> {
@@ -46,7 +46,7 @@ impl ValueRef {
         for x in values {
             dict.values.insert(x.0.to_string(), Self::int(x.1));
         }
-        Self::from(Value::dict_value(dict))
+        Self::from(Value::dict_value(Box::new(dict)))
     }
 
     pub fn dict_float(values: &[(&str, f64)]) -> Self {
@@ -54,7 +54,7 @@ impl ValueRef {
         for x in values {
             dict.values.insert(x.0.to_string(), Self::float(x.1));
         }
-        Self::from(Value::dict_value(dict))
+        Self::from(Value::dict_value(Box::new(dict)))
     }
 
     pub fn dict_bool(values: &[(&str, bool)]) -> Self {
@@ -62,7 +62,7 @@ impl ValueRef {
         for x in values {
             dict.values.insert(x.0.to_string(), Self::bool(x.1));
         }
-        Self::from(Value::dict_value(dict))
+        Self::from(Value::dict_value(Box::new(dict)))
     }
 
     pub fn dict_str(values: &[(&str, &str)]) -> Self {
@@ -70,7 +70,7 @@ impl ValueRef {
         for x in values {
             dict.values.insert(x.0.to_string(), Self::str(x.1));
         }
-        Self::from(Value::dict_value(dict))
+        Self::from(Value::dict_value(Box::new(dict)))
     }
 
     /// Dict clear
@@ -321,7 +321,7 @@ impl ValueRef {
                 dict.ops.insert(key.to_string(), op);
                 dict.insert_indexs.insert(key.to_string(), insert_index);
                 self.union(
-                    &ValueRef::from(Value::dict_value(dict)),
+                    &ValueRef::from(Value::dict_value(Box::new(dict))),
                     true,
                     false,
                     should_idempotent_check,

--- a/kclvm/runtime/src/value/val_from.rs
+++ b/kclvm/runtime/src/value/val_from.rs
@@ -92,7 +92,7 @@ macro_rules! define_value_list_from_iter_trait {
                 for i in iter {
                     list.values.push(i.into());
                 }
-                Self::from(Value::list_value(list))
+                Self::from(Value::list_value(Box::new(list)))
             }
         }
     };
@@ -103,7 +103,7 @@ macro_rules! define_value_list_from_iter_trait {
                 for i in iter {
                     list.values.push(i.into());
                 }
-                Self::from(Value::list_value(list))
+                Self::from(Value::list_value(Box::new(list)))
             }
         }
     };
@@ -116,9 +116,9 @@ define_value_list_from_iter_trait!(f64);
 define_value_list_from_iter_trait!(ref, str);
 define_value_list_from_iter_trait!(ref, ValueRef);
 
-define_value_try_from_trait!(ListValue, list_value);
+define_value_try_from_trait!(Box<ListValue>, list_value);
 
-define_value_try_into_method!(try_into_list, ListValue);
+define_value_try_into_method!(try_into_list, Box<ListValue>);
 
 // dict
 
@@ -130,7 +130,7 @@ macro_rules! define_value_dict_from_iter_trait {
                 for (k, v) in iter {
                     dict.values.insert(k.to_string(), v.into());
                 }
-                Self::from(Value::dict_value(dict))
+                Self::from(Value::dict_value(Box::new(dict)))
             }
         }
     };
@@ -141,7 +141,7 @@ macro_rules! define_value_dict_from_iter_trait {
                 for (k, v) in iter {
                     dict.values.insert(k.to_string(), v.into());
                 }
-                Self::from(Value::dict_value(dict))
+                Self::from(Value::dict_value(Box::new(dict)))
             }
         }
     };
@@ -153,13 +153,13 @@ define_value_dict_from_iter_trait!(f64);
 define_value_dict_from_iter_trait!(ref, str);
 define_value_dict_from_iter_trait!(ref, ValueRef);
 
-define_value_try_from_trait!(DictValue, dict_value);
+define_value_try_from_trait!(Box<DictValue>, dict_value);
 
-define_value_try_into_method!(try_into_dict, DictValue);
+define_value_try_into_method!(try_into_dict, Box<DictValue>);
 
 // schema
 
-define_value_try_from_trait!(SchemaValue, schema_value);
+define_value_try_from_trait!(Box<SchemaValue>, schema_value);
 
 #[cfg(test)]
 mod tests_from {
@@ -227,7 +227,7 @@ mod tests_from {
         let list = vec![1, 2, 4, 3];
 
         let list_value: ValueRef = ValueRef::from_iter(list.clone().into_iter());
-        let list_value: ListValue = list_value.try_into().unwrap();
+        let list_value: Box<ListValue> = list_value.try_into().unwrap();
 
         assert_eq!(
             list_value

--- a/kclvm/runtime/src/value/val_list.rs
+++ b/kclvm/runtime/src/value/val_list.rs
@@ -8,7 +8,7 @@ impl ValueRef {
         for _i in 0..size {
             list.values.push(val.clone());
         }
-        Self::from(Value::list_value(list))
+        Self::from(Value::list_value(Box::new(list)))
     }
 
     pub fn list_bool(x: &[bool]) -> Self {
@@ -16,7 +16,7 @@ impl ValueRef {
         for x in x.iter() {
             list.values.push(Self::bool(*x));
         }
-        Self::from(Value::list_value(list))
+        Self::from(Value::list_value(Box::new(list)))
     }
 
     pub fn list_int(x: &[i64]) -> Self {
@@ -24,7 +24,7 @@ impl ValueRef {
         for x in x.iter() {
             list.values.push(Self::int(*x));
         }
-        Self::from(Value::list_value(list))
+        Self::from(Value::list_value(Box::new(list)))
     }
 
     pub fn list_float(x: &[f64]) -> Self {
@@ -32,7 +32,7 @@ impl ValueRef {
         for x in x.iter() {
             list.values.push(Self::float(*x));
         }
-        Self::from(Value::list_value(list))
+        Self::from(Value::list_value(Box::new(list)))
     }
 
     pub fn list_str(x: &[String]) -> Self {
@@ -40,7 +40,7 @@ impl ValueRef {
         for x in x.iter() {
             list.values.push(Self::str((*x).as_ref()));
         }
-        Self::from(Value::list_value(list))
+        Self::from(Value::list_value(Box::new(list)))
     }
 
     pub fn list_resize(&mut self, newsize: usize) {

--- a/kclvm/runtime/src/value/val_plan.rs
+++ b/kclvm/runtime/src/value/val_plan.rs
@@ -224,7 +224,7 @@ impl ValueRef {
             },
             Value::list_value(ref v) => {
                 let mut list = ValueRef {
-                    rc: Rc::new(Value::list_value(ListValue { values: vec![] })),
+                    rc: Rc::new(Value::list_value(Box::new(ListValue { values: vec![] }))),
                 };
                 for x in v.values.iter() {
                     if !(x.is_undefined() || x.is_func() || ctx.cfg.disable_none && x.is_none()) {
@@ -235,12 +235,12 @@ impl ValueRef {
             }
             Value::dict_value(ref v) => {
                 let mut dict = ValueRef {
-                    rc: Rc::new(Value::dict_value(DictValue {
+                    rc: Rc::new(Value::dict_value(Box::new(DictValue {
                         values: IndexMap::default(),
                         ops: IndexMap::default(),
                         insert_indexs: IndexMap::default(),
                         attr_map: IndexMap::default(),
-                    })),
+                    }))),
                 };
                 for (key, val) in v.values.iter() {
                     if !(val.is_undefined()
@@ -259,7 +259,7 @@ impl ValueRef {
             }
             Value::schema_value(ref v) => {
                 let mut schema = ValueRef {
-                    rc: Rc::new(Value::schema_value(SchemaValue {
+                    rc: Rc::new(Value::schema_value(Box::new(SchemaValue {
                         name: v.name.clone(),
                         pkgpath: v.pkgpath.clone(),
                         config: Rc::new(DictValue {
@@ -269,7 +269,7 @@ impl ValueRef {
                             attr_map: IndexMap::default(),
                         }),
                         config_keys: vec![],
-                    })),
+                    }))),
                 };
                 for (key, val) in v.config.values.iter() {
                     if !val.is_undefined() && !val.is_func() {

--- a/kclvm/runtime/src/value/val_schema.rs
+++ b/kclvm/runtime/src/value/val_schema.rs
@@ -40,12 +40,12 @@ pub fn schema_config_meta(filename: &str, line: u64, column: u64) -> ValueRef {
 impl ValueRef {
     pub fn dict_to_schema(&self, name: &str, pkgpath: &str, config_keys: &[String]) -> Self {
         if self.is_dict() {
-            Self::from(Value::schema_value(SchemaValue {
+            Self::from(Value::schema_value(Box::new(SchemaValue {
                 name: name.to_string(),
                 pkgpath: pkgpath.to_string(),
                 config: Rc::new(self.as_dict_ref().clone()),
                 config_keys: config_keys.to_owned(),
-            }))
+            })))
         } else if self.is_schema() {
             self.clone()
         } else {
@@ -56,7 +56,7 @@ impl ValueRef {
     pub fn schema_to_dict(&self) -> Self {
         match &*self.rc {
             Value::schema_value(ref schema) => {
-                Self::from(Value::dict_value(schema.config.as_ref().clone()))
+                Self::from(Value::dict_value(Box::new(schema.config.as_ref().clone())))
             }
             Value::dict_value(_) => self.clone(),
             _ => panic!("invalid schema object to dict"),

--- a/kclvm/runtime/src/value/val_union.rs
+++ b/kclvm/runtime/src/value/val_union.rs
@@ -79,11 +79,12 @@ impl ValueRef {
                                 (Value::list_value(origin_value), Value::list_value(value)) => {
                                     // As RefMut
                                     let origin_value: &mut ListValue = unsafe {
-                                        &mut *(origin_value as *const ListValue as *mut ListValue)
+                                        &mut *(&**origin_value as *const ListValue
+                                            as *mut ListValue)
                                     };
                                     // As RefMut
                                     let value: &mut ListValue = unsafe {
-                                        &mut *(value as *const ListValue as *mut ListValue)
+                                        &mut *(&**value as *const ListValue as *mut ListValue)
                                     };
                                     if index == -1 {
                                         origin_value.values.append(&mut value.clone().values);


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kusionstack/KCLVM/kclvm-parser 
-->
kclvm/runtime
#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->
use std::box to avoid unnecessary memory alloc
from
```rust
pub enum Value {
    undefined,
    none,
    bool_value(bool),
    int_value(i64),
    float_value(f64),
    str_value(String),
    list_value(ListValue),
    dict_value(DictValue),
    schema_value(SchemaValue),
    func_value(FuncValue),
    unit_value(f64, i64, String), // (Real value, raw value, unit string)
}

```
to
```rust
pub enum Value {
    undefined,
    none,
    bool_value(bool),
    int_value(i64),
    float_value(f64),
    str_value(String),
    list_value(Box<ListValue>),
    dict_value(Box<DictValue>),
    schema_value(Box<SchemaValue>),
    func_value(Box<FuncValue>),
    unit_value(f64, i64, String), // (Real value, raw value, unit string)
}
```

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [x] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
None
```
