### PR TITLE
Feat(compiler-base-error): add default() to DiagnosticHandler.

### DIFF
--- a/compiler_base/error/Cargo.toml
+++ b/compiler_base/error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiler_base_error"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2021"
 authors = ["zongzhe1024@163.com"]
 license = "Apache-2.0 OR MIT"

--- a/compiler_base/error/src/diagnostic/diagnostic_handler.rs
+++ b/compiler_base/error/src/diagnostic/diagnostic_handler.rs
@@ -107,12 +107,22 @@ impl Debug for DiagnosticHandler {
 }
 
 impl DiagnosticHandler {
+    /// Create a `DiagnosticHandler` with no (*.ftl) template files.
+    /// Use this method if the diagnostic message does not need to be loaded from the template file (*.ftl).
+    pub fn default() -> Self {
+        Self {
+            handler_inner: Mutex::new(DiagnosticHandlerInner::default()),
+        }
+    }
+
     /// Load all (*.ftl) template files under default directory.
     ///
     /// Default directory "./src/diagnostic/locales/en-US/"
     /// Call the constructor 'new_with_template_dir()' to load the file.
     /// For more information about the constructor 'new_with_template_dir()', see the doc above 'new_with_template_dir()'.
-    pub fn default() -> Result<Self> {
+    ///
+    /// Note: This method has not been completed, and it may throw an error that the file path does not exist.
+    pub fn new_with_default_template_dir() -> Result<Self> {
         let mut cargo_file_path = PathBuf::from(DIAGNOSTIC_MESSAGES_ROOT);
         cargo_file_path.push(DEFAULT_TEMPLATE_RESOURCE);
         let abs_path = cargo_file_path.to_str().with_context(|| {
@@ -532,6 +542,16 @@ impl Debug for DiagnosticHandlerInner {
 }
 
 impl DiagnosticHandlerInner {
+    pub(crate) fn default() -> Self {
+        Self {
+            err_count: 0,
+            warn_count: 0,
+            emitter: Box::new(TerminalEmitter::default()),
+            diagnostics: vec![],
+            template_loader: Arc::new(TemplateLoader::default()),
+        }
+    }
+
     /// Load all (*.ftl) template files under directory `template_dir`.
     pub(crate) fn new_with_template_dir(template_dir: &str) -> Result<Self> {
         let template_loader = TemplateLoader::new_with_template_dir(template_dir)

--- a/compiler_base/error/src/diagnostic/diagnostic_message.rs
+++ b/compiler_base/error/src/diagnostic/diagnostic_message.rs
@@ -18,6 +18,13 @@ pub(crate) struct TemplateLoader {
 }
 
 impl TemplateLoader {
+    /// Create an empty TemplateLoader that does not load any template files(*.ftl).
+    pub(crate) fn default() -> Self {
+        Self {
+            template_inner: Arc::new(TemplateLoaderInner::default()),
+        }
+    }
+
     /// Create the `TemplateLoader` with template (*.ftl) files directory.
     /// `TemplateLoader` will load all the files end with "*.ftl" under the directory recursively.
     /// template_files
@@ -77,6 +84,12 @@ struct TemplateLoaderInner {
 }
 
 impl TemplateLoaderInner {
+    fn default() -> Self {
+        Self {
+            template_bunder: FluentBundle::default(),
+        }
+    }
+
     fn new_with_template_dir(template_dir: &str) -> Result<Self> {
         let mut template_bunder = FluentBundle::new(vec![langid!("en-US")]);
         load_all_templates_in_dir_to_resources(template_dir, &mut template_bunder)

--- a/compiler_base/error/src/diagnostic/tests.rs
+++ b/compiler_base/error/src/diagnostic/tests.rs
@@ -253,7 +253,9 @@ mod test_error_message {
 
 mod test_diag_handler {
     use crate::{
-        components::Label, diagnostic_handler::DiagnosticHandler, Diagnostic, DiagnosticStyle,
+        components::Label,
+        diagnostic_handler::{DiagnosticHandler, MessageArgs},
+        Diagnostic, DiagnosticStyle,
     };
     use anyhow::{Context, Result};
     #[test]
@@ -268,7 +270,7 @@ mod test_diag_handler {
     }
 
     fn return_self_for_test() -> Result<()> {
-        DiagnosticHandler::default()?
+        DiagnosticHandler::new_with_default_template_dir()?
             .add_err_diagnostic(Diagnostic::<DiagnosticStyle>::new())?
             .add_warn_diagnostic(Diagnostic::<DiagnosticStyle>::new())?
             .emit_error_diagnostic(Diagnostic::<DiagnosticStyle>::new())?
@@ -281,11 +283,24 @@ mod test_diag_handler {
 
     #[test]
     fn test_diag_handler_fmt() {
-        let diag_handler = DiagnosticHandler::default().unwrap();
+        let diag_handler = DiagnosticHandler::new_with_default_template_dir().unwrap();
         let mut diag = Diagnostic::<DiagnosticStyle>::new();
         let err_label_1 = Box::new(Label::Error("E3033".to_string()));
         diag.append_component(err_label_1);
         diag_handler.add_err_diagnostic(diag).unwrap();
         assert_eq!(format!("{:?}", diag_handler), "[[StyledString { text: \"error\", style: Some(NeedFix) }, StyledString { text: \"[E3033]\", style: Some(Helpful) }]]\n");
+    }
+
+    #[test]
+    fn test_diag_handler_default() {
+        let diag_handler = DiagnosticHandler::default();
+        match diag_handler.get_diagnostic_msg("index", Some("sub_index"), &MessageArgs::default()) {
+            Ok(_) => {
+                panic!("Unreachable")
+            }
+            Err(err) => {
+                assert_eq!(format!("{:?}", err), "Message doesn't exist.")
+            }
+        };
     }
 }

--- a/compiler_base/session/Cargo.toml
+++ b/compiler_base/session/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiler_base_session"
-version = "0.0.7"
+version = "0.0.8"
 edition = "2021"
 authors = ["zongzhe1024@163.com"]
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION


issue #115.

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 

#115 

#### 2. What is the scope of this PR (e.g. component or file name):

compiler_base_error 

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [x] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

The new default method does not need to load the template file, which solves the problem that the template file path may not be found.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
None
```
