### PR TITLE
Fix(KCL-Vet): Turn the execution mode of KCL-Vet's test cases from parallel to serial.

### DIFF
--- a/kclvm/tools/src/vet/tests.rs
+++ b/kclvm/tools/src/vet/tests.rs
@@ -320,16 +320,15 @@ mod test_validater {
         &["test.k", "simple.k", "list.k", "plain_value.k", "complex.k"];
     const VALIDATED_FILE_TYPE: &'static [&'static str] = &["json", "yaml"];
 
-    // #[test]
-    // fn test_validator() {
-    //     // test_validate();
-    //     // test_invalid_validate();
-    //     // test_validate_with_invalid_kcl_path();
-    //     // test_validate_with_invalid_file_path();
-    //     // test_validate_with_invalid_file_type();
-    // }
-
     #[test]
+    fn test_validator() {
+        test_validate();
+        test_invalid_validate();
+        test_validate_with_invalid_kcl_path();
+        test_validate_with_invalid_file_path();
+        test_validate_with_invalid_file_type();
+    }
+
     fn test_validate() {
         for (i, file_suffix) in VALIDATED_FILE_TYPE.iter().enumerate() {
             for case in KCL_TEST_CASES {
@@ -357,7 +356,6 @@ mod test_validater {
         }
     }
 
-    #[test]
     fn test_invalid_validate() {
         let prev_hook = std::panic::take_hook();
         // disable print panic info
@@ -421,7 +419,6 @@ mod test_validater {
         std::panic::set_hook(prev_hook);
     }
 
-    #[test]
     fn test_validate_with_invalid_kcl_path() {
         let opt = ValidateOption::new(
             None,
@@ -443,7 +440,6 @@ mod test_validater {
         }
     }
 
-    #[test]
     fn test_validate_with_invalid_file_path() {
         let kcl_code = fs::read_to_string(
             construct_full_path(&format!("{}/{}", "validate_cases", "test.k")).unwrap(),
@@ -469,7 +465,6 @@ mod test_validater {
         }
     }
 
-    #[test]
     fn test_validate_with_invalid_file_type() {
         let kcl_code = fs::read_to_string(
             construct_full_path(&format!("{}/{}", "validate_cases", "test.k")).unwrap(),


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 

issue #277

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

KCL-Vet

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

Add test case 'test_validator' for KCL-Vet to turn the execution mode of KCL-Vet's test cases from parallel to serial.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
None
```
