### PR TITLE
Fix(KCL-Vet): Turn the execution mode of kclvm-runner test cases from parallel to serial.

### DIFF
--- a/kclvm/runner/src/tests.rs
+++ b/kclvm/runner/src/tests.rs
@@ -202,7 +202,6 @@ fn assemble_lib_for_test(
     )
 }
 
-#[test]
 fn test_kclvm_runner_execute() {
     for case in TEST_CASES {
         let kcl_path = &format!("{}/{}/{}", TEST_CASE_PATH, case, KCL_FILE_NAME);
@@ -213,7 +212,6 @@ fn test_kclvm_runner_execute() {
     }
 }
 
-#[test]
 fn test_kclvm_runner_execute_timeout() {
     set_hook(Box::new(|_| {}));
     let result_time_out = catch_unwind(|| {
@@ -361,7 +359,6 @@ fn test_from_setting_file_program_arg() {
     }
 }
 
-#[test]
 fn test_exec_file() {
     let prev_hook = std::panic::take_hook();
     // disable print panic info
@@ -373,6 +370,13 @@ fn test_exec_file() {
     });
     assert!(result.is_ok());
     std::panic::set_hook(prev_hook);
+}
+
+#[test]
+fn test_exec() {
+    test_exec_file();
+    test_kclvm_runner_execute();
+    test_kclvm_runner_execute_timeout();
 }
 
 fn exec(file: &str) -> Result<String, String> {


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 

issue #277

#### 2. What is the scope of this PR (e.g. component or file name):

kclvm-runner

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

Add test case 'test_exec' for kclvm-runner to turn the execution mode of kclvm-runner test cases from parallel to serial.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
None
```
