### PR TITLE
fix : avoid borrowing same ref in ValRef.union

### DIFF
--- a/kclvm/runtime/src/api/kclvm.rs
+++ b/kclvm/runtime/src/api/kclvm.rs
@@ -194,6 +194,11 @@ impl Default for ValueRef {
 }
 
 impl ValueRef {
+    // Returns whether self and x refer to the same Value
+    pub fn is_same_ref(&self, x: &Self) -> bool {
+        std::ptr::eq(&*self.rc.borrow(), &*x.rc.borrow())
+    }
+
     pub fn into_raw(self) -> *mut Self {
         new_mut_ptr(self)
     }

--- a/kclvm/runtime/src/value/val_union.rs
+++ b/kclvm/runtime/src/value/val_union.rs
@@ -11,6 +11,10 @@ impl ValueRef {
         should_idempotent_check: bool,
         should_config_resolve: bool,
     ) -> Self {
+        if self.is_same_ref(x) {
+            return self.clone();
+        }
+
         let union_fn = |obj: &mut DictValue, delta: &DictValue| {
             // Update attribute map
             for (k, v) in &delta.ops {
@@ -72,6 +76,9 @@ impl ValueRef {
                                 obj.values.insert(k.to_string(), list);
                             }
                             let origin_value = obj.values.get_mut(k).unwrap();
+                            if origin_value.is_same_ref(v) {
+                                continue;
+                            }
                             match (&mut *origin_value.rc.borrow_mut(), &*v.rc.borrow()) {
                                 (Value::list_value(origin_value), Value::list_value(value)) => {
                                     if index == -1 {
@@ -230,7 +237,7 @@ impl ValueRef {
         should_config_resolve: bool,
     ) -> Self {
         self.union(
-            &x.deep_copy(),
+            x,
             or_mode,
             should_list_override,
             should_idempotent_check,


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kusionstack/KCLVM/kclvm-parser 
-->

[kclvm/runtime/src/value/val_union.rs](https://github.com/KusionStack/KCLVM/compare/main...NeverRaR:dev/boying/runtime/union?expand=1#diff-8ae99b27301ecf8eea5c108497fa1842e3b9e6ddb9172757bb685f0c190f99a3)

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->
fix : avoid borrowing same ref in ValRef.union

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->
The test cases in  /kclvm/src/runtime/value/value_union.rs.test_dict_union_same_ref() are used to test union the ValueRef
with itself.
#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
None
```
