### PR TITLE
[WIP] Fix(kclvm-parser): Added 'lookbehind' method in lexer.

### DIFF
--- a/kclvm/parser/src/lexer/mod.rs
+++ b/kclvm/parser/src/lexer/mod.rs
@@ -434,15 +434,18 @@ impl<'a> Lexer<'a> {
         })
     }
 
-    // From the lexed tokens stack, check whether the token at the top of the stack and the current character can combine a new token.
-    // If yes, lexer will pop the token at the top of the stack and return a new token combined with the token poped and the current character.
-    // If not, return None.
+    /// From the lexed tokens stack, check whether the token at the top of the stack and the current character can combine a new token.
+    /// If yes, lexer will pop the token at the top of the stack and return a new token combined with the token poped and the current character.
+    /// If not, return None.
     fn look_behind(
         &mut self,
         tok: &kclvm_lexer::Token,
         tok_stream_builder: &mut TokenStreamBuilder,
     ) -> Option<TokenKind> {
         match tok.kind {
+            // Most multi-character tokens are lexed in ['kclvm-lexer'],
+            // and the multi-character tokens that need to be lexed in ['kclvm-parser/lexer'] are only token '->'.
+            // If a new multi-character token is added later, the corresponding operation can be added here.
             kclvm_lexer::TokenKind::Gt => {
                 if let Some(_) =
                     tok_stream_builder.pop_if_tok_kind(&TokenKind::BinOp(BinOpToken::Minus))
@@ -728,13 +731,13 @@ impl TokenStreamBuilder {
         self.buf.push(token)
     }
 
-    // Pop the token at the top of the stack, and return None if the stack is empty.
+    /// Pop the token at the top of the stack, and return None if the stack is empty.
     fn pop(&mut self) -> Option<Token> {
         self.buf.pop()
     }
 
-    // If the token kind at the top of the stack is 'expected_tok_kind',
-    // pop the token and return it, otherwise do nothing and return None.
+    /// If the token kind at the top of the stack is 'expected_tok_kind',
+    /// pop the token and return it, otherwise do nothing and return None.
     fn pop_if_tok_kind(&mut self, expected_tok_kind: &TokenKind) -> Option<Token> {
         if self.peek_tok_kind() == expected_tok_kind {
             self.pop()
@@ -743,7 +746,7 @@ impl TokenStreamBuilder {
         }
     }
 
-    // Peek the kind of the token on the top of the stack.
+    /// Peek the kind of the token on the top of the stack.
     fn peek_tok_kind(&self) -> &TokenKind {
         match self.buf.last() {
             Some(tok) => &tok.kind,

--- a/kclvm/parser/src/lexer/mod.rs
+++ b/kclvm/parser/src/lexer/mod.rs
@@ -22,10 +22,12 @@ mod string;
 mod tests;
 
 use kclvm_ast::ast::NumberBinarySuffix;
+use kclvm_ast::token::BinOpToken;
+use kclvm_ast::token::TokenKind;
 use kclvm_ast::token::{self, CommentKind, Token};
 use kclvm_ast::token_stream::TokenStream;
 use kclvm_error::bug;
-use kclvm_lexer::{Base};
+use kclvm_lexer::Base;
 use kclvm_span::symbol::Symbol;
 use kclvm_span::{self, BytePos, Span};
 use rustc_span::Pos;
@@ -42,6 +44,7 @@ pub fn parse_token_streams(sess: &ParseSession, src: &str, start_pos: BytePos) -
         sess,
         start_pos,
         pos: start_pos,
+        tok_start_pos: start_pos,
         end_src_index: src.len(),
         src,
         token: TokenWithIndents::Token {
@@ -76,18 +79,6 @@ enum IndentOrDedents {
 }
 
 impl TokenWithIndents {
-
-    pub(crate) fn is_dummy(&self) -> bool {
-        self.get_tok_kind() == kclvm_ast::token::TokenKind::Dummy
-    }
-
-    pub(crate) fn get_tok_kind(&self) -> kclvm_ast::token::TokenKind {
-        match self {
-            TokenWithIndents::Token { token } => token.kind,
-            TokenWithIndents::WithIndent { token, indent: _ } => token.kind,
-        }
-    }
-
     pub(crate) fn is_eof(&self) -> bool {
         match self {
             TokenWithIndents::Token { token } => *token == token::Eof,
@@ -125,6 +116,9 @@ struct Lexer<'a> {
     /// The absolute offset within the source_map of the current character.
     pos: BytePos,
 
+    /// The start position of the current token.
+    tok_start_pos: BytePos,
+
     /// Stop reading src at this index.
     end_src_index: usize,
 
@@ -146,7 +140,7 @@ struct IndentContext {
     new_line_beginning: bool,
 
     /// Delim stack
-    delims: Vec<kclvm_ast::token::TokenKind>,
+    delims: Vec<TokenKind>,
 
     /// tab counter
     tabs: usize,
@@ -161,18 +155,23 @@ struct IndentContext {
 impl<'a> Lexer<'a> {
     fn into_tokens(mut self) -> TokenStream {
         let mut buf = TokenStreamBuilder::default();
-        self.token = self.token();
+        // In the process of look-behind lexing, it is necessary to check the type of the previous token in 'buf',
+        // If the previous token and the current token can form a multi-character token,
+        // then the previous token will be popped from 'buf'.
+        //
+        // Therefore, the method 'self.token()' needs to take the mutable reference of 'buf' as an incoming argument.
+        self.token = self.token(&mut buf);
 
         while !self.token.is_eof() {
             self.token.append_to(&mut buf);
-            self.token = self.token();
+            self.token = self.token(&mut buf);
         }
 
         self.eof(&mut buf);
         buf.into_token_stream()
     }
 
-    fn token(&mut self) -> TokenWithIndents {
+    fn token(&mut self, tok_stream_builder: &mut TokenStreamBuilder) -> TokenWithIndents {
         loop {
             let start_src_index = self.src_index(self.pos);
             let text: &str = &self.src[start_src_index..self.end_src_index];
@@ -189,12 +188,19 @@ impl<'a> Lexer<'a> {
             // Detect and handle indent cases before lexing on-going token
             let indent = self.lex_indent_context(token.kind);
 
-            let start = self.pos;
+            // Because of the 'look-behind', the 'start' of the current token becomes a two-way cursor,
+            // which can not only move forward, but also move backward when 'look-behind'.
+            // Therefore, the value of 'self.tok_start_pos' can be changed in 'self.lex_token()'.
+            self.tok_start_pos = self.pos;
             // update pos after token and indent handling
             self.pos = self.pos + BytePos::from_usize(token.len);
 
-            if let Some(kind) = self.lex_token(token, start) {
-                let span = self.span(start, self.pos);
+            // In the process of look-behind lexing, it is necessary to check the type of the previous token in 'tok_stream_builder',
+            // If the previous token and the current token can form a multi-character token,
+            // then the previous token will be popped from 'tok_stream_builder'.
+            // Therefore, the method 'self.lex_token()' needs to take the mutable reference of 'tok_stream_builder' as an incoming argument.
+            if let Some(kind) = self.lex_token(token, self.tok_start_pos, tok_stream_builder) {
+                let span = self.span(self.tok_start_pos, self.pos);
 
                 match indent {
                     Some(iord) => {
@@ -216,7 +222,12 @@ impl<'a> Lexer<'a> {
     }
 
     /// Turns `kclvm_lexer::TokenKind` into a rich `kclvm_ast::TokenKind`.
-    fn lex_token(&mut self, token: kclvm_lexer::Token, start: BytePos) -> Option<kclvm_ast::token::TokenKind> {
+    fn lex_token(
+        &mut self,
+        token: kclvm_lexer::Token,
+        start: BytePos,
+        tok_stream_builder: &mut TokenStreamBuilder,
+    ) -> Option<TokenKind> {
         Some(match token.kind {
             kclvm_lexer::TokenKind::LineComment { doc_style: _ } => {
                 let s = self.str_from(start);
@@ -253,22 +264,6 @@ impl<'a> Lexer<'a> {
             // Binary op
             kclvm_lexer::TokenKind::Plus => token::BinOp(token::Plus),
             kclvm_lexer::TokenKind::Minus => token::BinOp(token::Minus),
-            // kclvm_lexer::TokenKind::Minus => {
-            //     let head = start + BytePos::from_u32(1);
-            //     let tail = start + BytePos::from_u32(2);
-            //     if self.has_next_token(head, tail) {
-            //         let next_tkn = self.str_from_to(head, tail);
-            //         if next_tkn == ">" {
-            //             // waste '>' token
-            //             self.pos = self.pos + BytePos::from_usize(1);
-            //             token::RArrow
-            //         } else {
-            //             token::BinOp(token::Minus)
-            //         }
-            //     } else {
-            //         token::BinOp(token::Minus)
-            //     }
-            // }
             kclvm_lexer::TokenKind::Star => token::BinOp(token::Star),
             kclvm_lexer::TokenKind::Slash => token::BinOp(token::Slash),
             kclvm_lexer::TokenKind::Percent => token::BinOp(token::Percent),
@@ -297,12 +292,12 @@ impl<'a> Lexer<'a> {
             kclvm_lexer::TokenKind::BangEq => token::BinCmp(token::NotEq),
             kclvm_lexer::TokenKind::Lt => token::BinCmp(token::Lt),
             kclvm_lexer::TokenKind::LtEq => token::BinCmp(token::LtEq),
-            kclvm_lexer::TokenKind::Gt => {
-                // 这里要尝试回去glue一下
-                match self.glue(kclvm_lexer::TokenKind::Gt, self.token.get_tok_kind()) {
-                    Some(tok) => {tok},
-                    None => {token::BinCmp(token::Gt)},
-                }
+            // If the current token is '>',
+            // then lexer need to check whether the previous token is '-',
+            // if yes, return token '->', if not return token '>'.
+            kclvm_lexer::TokenKind::Gt => match self.look_behind(&token, tok_stream_builder) {
+                Some(tok_kind) => tok_kind,
+                None => token::BinCmp(token::Gt),
             },
             kclvm_lexer::TokenKind::GtEq => token::BinCmp(token::GtEq),
             // Structural symbols
@@ -439,20 +434,31 @@ impl<'a> Lexer<'a> {
         })
     }
 
-    fn glue(&self, tok_kind: kclvm_lexer::TokenKind, last_tok_kind: kclvm_ast::token::TokenKind) -> Option<kclvm_ast::token::TokenKind> {
-        match tok_kind {
-            kclvm_lexer::TokenKind::Gt => match last_tok_kind {
-                kclvm_ast::token::TokenKind::BinOp(bin_op) => {
-                    if let kclvm_ast::token::BinOpToken::Minus = bin_op {
-                        Some(kclvm_ast::token::TokenKind::RArrow)
+    // From the lexed tokens stack, check whether the token at the top of the stack and the current character can combine a new token.
+    // If yes, lexer will pop the token at the top of the stack and return a new token combined with the token poped and the current character.
+    // If not, return None.
+    fn look_behind(
+        &mut self,
+        tok: &kclvm_lexer::Token,
+        tok_stream_builder: &mut TokenStreamBuilder,
+    ) -> Option<TokenKind> {
+        match tok.kind {
+            kclvm_lexer::TokenKind::Gt => {
+                if let Some(_) =
+                    tok_stream_builder.pop_if_tok_kind(&TokenKind::BinOp(BinOpToken::Minus))
+                {
+                    // After the previous token pops up, 'self.tok_start_pos' needs to be updated.
+                    if self.tok_start_pos >= BytePos::from_usize(1) {
+                        self.tok_start_pos = self.tok_start_pos - BytePos::from_usize(1);
+                        return Some(TokenKind::RArrow);
                     } else {
-                        None
+                        bug!("Internal Bugs: Please connect us to fix it, invalid token start pos")
                     }
-                },
-                kclvm_ast::token::TokenKind::Dummy | _ => None,
-            },
-            _ => None
+                }
+            }
+            _ => return None,
         }
+        None
     }
 
     fn lex_literal(
@@ -720,6 +726,29 @@ struct TokenStreamBuilder {
 impl TokenStreamBuilder {
     fn push(&mut self, token: Token) {
         self.buf.push(token)
+    }
+
+    // Pop the token at the top of the stack, and return None if the stack is empty.
+    fn pop(&mut self) -> Option<Token> {
+        self.buf.pop()
+    }
+
+    // If the token kind at the top of the stack is 'expected_tok_kind',
+    // pop the token and return it, otherwise do nothing and return None.
+    fn pop_if_tok_kind(&mut self, expected_tok_kind: &TokenKind) -> Option<Token> {
+        if self.peek_tok_kind() == expected_tok_kind {
+            self.pop()
+        } else {
+            None
+        }
+    }
+
+    // Peek the kind of the token on the top of the stack.
+    fn peek_tok_kind(&self) -> &TokenKind {
+        match self.buf.last() {
+            Some(tok) => &tok.kind,
+            None => &TokenKind::Dummy,
+        }
     }
 
     fn into_token_stream(self) -> TokenStream {

--- a/kclvm/parser/src/lexer/tests.rs
+++ b/kclvm/parser/src/lexer/tests.rs
@@ -6,7 +6,7 @@ use kclvm_span::{create_session_globals_then, BytePos, FilePathMapping, SourceMa
 use std::path::PathBuf;
 use std::sync::Arc;
 
-// lexing the 'src'.
+/// lexing the 'src'.
 fn lex(src: &str) -> String {
     let sm = SourceMap::new(FilePathMapping::empty());
     sm.new_source_file(PathBuf::from("").into(), src.to_string());
@@ -20,7 +20,7 @@ fn lex(src: &str) -> String {
     })
 }
 
-// check the invalid panic message.
+/// check the invalid panic message.
 fn check_lexing_invalid(src: &str, expect: Expect) {
     let prev_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(|_info| {}));
@@ -39,7 +39,7 @@ fn check_lexing_invalid(src: &str, expect: Expect) {
     }
 }
 
-// check the lexing result.
+/// check the lexing result.
 fn check_lexing(src: &str, expect: Expect) {
     expect.assert_eq(&lex(src));
 }

--- a/kclvm/parser/src/lexer/tests.rs
+++ b/kclvm/parser/src/lexer/tests.rs
@@ -6,18 +6,42 @@ use kclvm_span::{create_session_globals_then, BytePos, FilePathMapping, SourceMa
 use std::path::PathBuf;
 use std::sync::Arc;
 
-fn check_lexing(src: &str, expect: Expect) {
+// lexing the 'src'.
+fn lex(src: &str) -> String {
     let sm = SourceMap::new(FilePathMapping::empty());
     sm.new_source_file(PathBuf::from("").into(), src.to_string());
     let sess = &ParseSession::with_source_map(Arc::new(sm));
 
     create_session_globals_then(|| {
-        let actual: String = parse_token_streams(sess, src, BytePos::from_u32(0))
+        parse_token_streams(sess, src, BytePos::from_u32(0))
             .iter()
             .map(|token| format!("{:?}\n", token))
-            .collect();
-        expect.assert_eq(&actual)
-    });
+            .collect()
+    })
+}
+
+// check the invalid panic message.
+fn check_lexing_invalid(src: &str, expect: Expect) {
+    let prev_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_info| {}));
+    let lex_invalid_result = std::panic::catch_unwind(|| lex(src));
+    std::panic::set_hook(prev_hook);
+
+    match lex_invalid_result {
+        Ok(_) => panic!("This test case should failed."),
+        Err(panic_err) => {
+            if let Some(s) = panic_err.downcast_ref::<String>() {
+                expect.assert_eq(s)
+            } else {
+                panic!("This test case should raise error message by 'String'.");
+            };
+        }
+    }
+}
+
+// check the lexing result.
+fn check_lexing(src: &str, expect: Expect) {
+    expect.assert_eq(&lex(src));
 }
 
 #[test]
@@ -487,4 +511,137 @@ a=1
         Token { kind: Eof, span: Span { base_or_index: 5, len_or_tag: 0 } }
         "#]],
     )
+}
+
+#[test]
+fn test_rarrow() {
+    check_lexing(
+        "lambda x: int, y: int -> int { x + y }\n",
+        expect![[r#"
+        Token { kind: Ident(Symbol(SymbolIndex { idx: 18 })), span: Span { base_or_index: 0, len_or_tag: 6 } }
+        Token { kind: Ident(Symbol(SymbolIndex { idx: 42 })), span: Span { base_or_index: 7, len_or_tag: 1 } }
+        Token { kind: Colon, span: Span { base_or_index: 8, len_or_tag: 1 } }
+        Token { kind: Ident(Symbol(SymbolIndex { idx: 30 })), span: Span { base_or_index: 10, len_or_tag: 3 } }
+        Token { kind: Comma, span: Span { base_or_index: 13, len_or_tag: 1 } }
+        Token { kind: Ident(Symbol(SymbolIndex { idx: 43 })), span: Span { base_or_index: 15, len_or_tag: 1 } }
+        Token { kind: Colon, span: Span { base_or_index: 16, len_or_tag: 1 } }
+        Token { kind: Ident(Symbol(SymbolIndex { idx: 30 })), span: Span { base_or_index: 18, len_or_tag: 3 } }
+        Token { kind: RArrow, span: Span { base_or_index: 22, len_or_tag: 2 } }
+        Token { kind: Ident(Symbol(SymbolIndex { idx: 30 })), span: Span { base_or_index: 25, len_or_tag: 3 } }
+        Token { kind: OpenDelim(Brace), span: Span { base_or_index: 29, len_or_tag: 1 } }
+        Token { kind: Ident(Symbol(SymbolIndex { idx: 42 })), span: Span { base_or_index: 31, len_or_tag: 1 } }
+        Token { kind: BinOp(Plus), span: Span { base_or_index: 33, len_or_tag: 1 } }
+        Token { kind: Ident(Symbol(SymbolIndex { idx: 43 })), span: Span { base_or_index: 35, len_or_tag: 1 } }
+        Token { kind: CloseDelim(Brace), span: Span { base_or_index: 37, len_or_tag: 1 } }
+        Token { kind: Newline, span: Span { base_or_index: 38, len_or_tag: 1 } }
+        Token { kind: Eof, span: Span { base_or_index: 39, len_or_tag: 0 } }
+        "#]],
+    );
+}
+
+#[test]
+fn test_minus_unicode_gt_invalid() {
+    check_lexing_invalid(
+        "lambda x: int, y: int -\u{feff}> int { x + y }\n",
+        expect![[r#"
+        {"__kcl_PanicInfo__":true,"rust_file":"","rust_line":0,"rust_col":0,"kcl_pkgpath":"","kcl_file":"","kcl_line":1,"kcl_col":24,"kcl_arg_msg":"","kcl_config_meta_file":"","kcl_config_meta_line":0,"kcl_config_meta_col":0,"kcl_config_meta_arg_msg":"","message":"Invalid syntax: unknown start of token","err_type_code":5,"is_warning":false}"#]],
+    );
+}
+
+#[test]
+fn test_unicode_minus_gt_invalid() {
+    check_lexing_invalid(
+        "lambda x: int, y: int \u{feff}-> int { x + y }\n",
+        expect![[r#"
+        {"__kcl_PanicInfo__":true,"rust_file":"","rust_line":0,"rust_col":0,"kcl_pkgpath":"","kcl_file":"","kcl_line":1,"kcl_col":23,"kcl_arg_msg":"","kcl_config_meta_file":"","kcl_config_meta_line":0,"kcl_config_meta_col":0,"kcl_config_meta_arg_msg":"","message":"Invalid syntax: unknown start of token","err_type_code":5,"is_warning":false}"#]],
+    );
+}
+
+#[test]
+fn test_minus_gt_unicode_invalid() {
+    check_lexing_invalid(
+        "lambda x: int, y: int ->\u{feff} int { x + y }\n",
+        expect![[r#"
+        {"__kcl_PanicInfo__":true,"rust_file":"","rust_line":0,"rust_col":0,"kcl_pkgpath":"","kcl_file":"","kcl_line":1,"kcl_col":25,"kcl_arg_msg":"","kcl_config_meta_file":"","kcl_config_meta_line":0,"kcl_config_meta_col":0,"kcl_config_meta_arg_msg":"","message":"Invalid syntax: unknown start of token","err_type_code":5,"is_warning":false}"#]],
+    );
+}
+
+#[test]
+fn test_only_minus() {
+    check_lexing(
+        "-",
+        expect![[r#"
+        Token { kind: BinOp(Minus), span: Span { base_or_index: 0, len_or_tag: 1 } }
+        Token { kind: Newline, span: Span { base_or_index: 1, len_or_tag: 0 } }
+        Token { kind: Eof, span: Span { base_or_index: 1, len_or_tag: 0 } }
+        "#]],
+    );
+}
+
+#[test]
+fn test_begin_with_minus() {
+    check_lexing(
+        "-123",
+        expect![[r#"
+        Token { kind: BinOp(Minus), span: Span { base_or_index: 0, len_or_tag: 1 } }
+        Token { kind: Literal(Lit { kind: Integer, symbol: Symbol(SymbolIndex { idx: 42 }), suffix: None, raw: None }), span: Span { base_or_index: 1, len_or_tag: 3 } }
+        Token { kind: Newline, span: Span { base_or_index: 4, len_or_tag: 0 } }
+        Token { kind: Eof, span: Span { base_or_index: 4, len_or_tag: 0 } }
+        "#]],
+    );
+}
+
+#[test]
+fn test_only_gt() {
+    check_lexing(
+        ">",
+        expect![[r#"
+        Token { kind: BinCmp(Gt), span: Span { base_or_index: 0, len_or_tag: 1 } }
+        Token { kind: Newline, span: Span { base_or_index: 1, len_or_tag: 0 } }
+        Token { kind: Eof, span: Span { base_or_index: 1, len_or_tag: 0 } }
+        "#]],
+    );
+}
+
+#[test]
+fn test_begin_with_gt() {
+    check_lexing(
+        ">sdjkd + ==",
+        expect![[r#"
+        Token { kind: BinCmp(Gt), span: Span { base_or_index: 0, len_or_tag: 1 } }
+        Token { kind: Ident(Symbol(SymbolIndex { idx: 42 })), span: Span { base_or_index: 1, len_or_tag: 5 } }
+        Token { kind: BinOp(Plus), span: Span { base_or_index: 7, len_or_tag: 1 } }
+        Token { kind: BinCmp(Eq), span: Span { base_or_index: 9, len_or_tag: 2 } }
+        Token { kind: Newline, span: Span { base_or_index: 11, len_or_tag: 0 } }
+        Token { kind: Eof, span: Span { base_or_index: 11, len_or_tag: 0 } }
+        "#]],
+    );
+}
+
+#[test]
+fn test_double_rarrow() {
+    check_lexing(
+        "->->",
+        expect![[r#"
+        Token { kind: RArrow, span: Span { base_or_index: 0, len_or_tag: 2 } }
+        Token { kind: RArrow, span: Span { base_or_index: 2, len_or_tag: 2 } }
+        Token { kind: Newline, span: Span { base_or_index: 4, len_or_tag: 0 } }
+        Token { kind: Eof, span: Span { base_or_index: 4, len_or_tag: 0 } }
+        "#]],
+    );
+}
+
+#[test]
+fn test_mess_rarrow() {
+    check_lexing(
+        "-->>->",
+        expect![[r#"
+        Token { kind: BinOp(Minus), span: Span { base_or_index: 0, len_or_tag: 1 } }
+        Token { kind: BinOp(Minus), span: Span { base_or_index: 1, len_or_tag: 1 } }
+        Token { kind: BinOp(Shr), span: Span { base_or_index: 2, len_or_tag: 2 } }
+        Token { kind: RArrow, span: Span { base_or_index: 4, len_or_tag: 2 } }
+        Token { kind: Newline, span: Span { base_or_index: 6, len_or_tag: 0 } }
+        Token { kind: Eof, span: Span { base_or_index: 6, len_or_tag: 0 } }
+        "#]],
+    );
 }


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 

issue #65.

#### 2. What is the scope of this PR (e.g. component or file name):

kclvm_lexer/parser

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

Added 'lookbehind' method in lexer.
For code containing unicode characters, find unicode characters in advance through lookbehind and report an error.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
None
```
