### PR TITLE
Fix(kclvm-windows): rm '\\?\' in windows path.

### DIFF
--- a/kclvm/runner/src/command.rs
+++ b/kclvm/runner/src/command.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 use std::env::consts::DLL_SUFFIX;
 use std::ffi::CString;
+use std::path::Path;
 use std::path::PathBuf;
 
 #[derive(Debug)]
@@ -103,6 +104,12 @@ impl Command {
             .host(&target)
             .flag("-o")
             .flag(&lib_path);
+
+        let libs: Vec<String> = libs
+            .into_iter()
+            .map(|lib| adjust_canonicalization(lib))
+            .collect();
+        let libs = libs.as_slice();
         build.files(libs);
 
         // Run command with cc.
@@ -222,5 +229,24 @@ impl Command {
                 })
                 .next()
         })
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn adjust_canonicalization<P: AsRef<Path>>(p: P) -> String {
+    p.as_ref().display().to_string()
+}
+
+#[cfg(target_os = "windows")]
+/// On windows, the "\\? \ " will cause the obj file to not be found when linking by "cl.exe".
+/// Slicing this path directly is not a good solution,
+/// we will find a more fluent way to solve this problem in the future. @zongz
+fn adjust_canonicalization<P: AsRef<Path>>(p: P) -> String {
+    const VERBATIM_PREFIX: &str = r#"\\?\"#;
+    let p = p.as_ref().display().to_string();
+    if p.starts_with(VERBATIM_PREFIX) {
+        p[VERBATIM_PREFIX.len()..].to_string()
+    } else {
+        p
     }
 }

--- a/scripts/build-windows/clean.bat
+++ b/scripts/build-windows/clean.bat
@@ -5,5 +5,9 @@ setlocal
 cd %~dp0
 
 rmdir _output
+del /s *.obj
+del /s *.exp
+del /s *.lib
+del /s *.dll
 
 del *.zip


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 

issue #379 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kusionstack/KCLVM/kclvm-parser 
-->

kclvm-windows.

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

rm '\\?\' in windows path for 'cl.exe'.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [x] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
None
```
