### PR TITLE
Feat(compiler_base_error): Add methods to the `DiagnosticHandler` that emits `Diagnostic` as string.

### DIFF
--- a/compiler_base/error/Cargo.toml
+++ b/compiler_base/error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiler_base_error"
-version = "0.0.8"
+version = "0.0.9"
 edition = "2021"
 authors = ["zongzhe1024@163.com"]
 license = "Apache-2.0 OR MIT"

--- a/compiler_base/error/src/diagnostic/diagnostic_handler.rs
+++ b/compiler_base/error/src/diagnostic/diagnostic_handler.rs
@@ -261,7 +261,6 @@ impl DiagnosticHandler {
     /// # Examples
     ///
     /// ```rust
-    ///
     /// use compiler_base_error::DiagnosticStyle;
     /// use compiler_base_error::diagnostic_handler::DiagnosticHandler;
     /// use compiler_base_error::Diagnostic;
@@ -281,6 +280,34 @@ impl DiagnosticHandler {
     pub fn emit_all_diags_into_string(&mut self) -> Result<Vec<Result<String>>> {
         match self.handler_inner.lock() {
             Ok(inner) => Ok(inner.emit_all_diags_into_string()),
+            Err(_) => bail!("Emit Diagnostics Failed."),
+        }
+    }
+
+    /// Emit the [`index`]th diagnostics into strings and return.
+    /// 
+    /// # Examples
+    /// 
+    /// ```rust
+    /// use compiler_base_error::DiagnosticStyle;
+    /// use compiler_base_error::diagnostic_handler::DiagnosticHandler;
+    /// use compiler_base_error::Diagnostic;
+    /// use compiler_base_error::components::Label;
+    ///
+    /// let mut diag_1 = Diagnostic::<DiagnosticStyle>::new();
+    /// diag_1.append_component(Box::new(Label::Note));
+    ///
+    /// let mut diag_handler = DiagnosticHandler::default();
+    ///
+    /// assert_eq!(diag_handler.diagnostics_count().unwrap(), 0);
+    ///
+    /// diag_handler.add_err_diagnostic(diag_1);
+    /// assert_eq!(diag_handler.diagnostics_count().unwrap(), 1);
+    /// assert_eq!(diag_handler.emit_nth_diag_into_string(0).unwrap().unwrap().unwrap(), "note");
+    /// ```
+    pub fn emit_nth_diag_into_string(&mut self, index: usize) -> Result<Option<Result<String>>> {
+        match self.handler_inner.lock() {
+            Ok(inner) => Ok(inner.emit_nth_diag_into_string(index)),
             Err(_) => bail!("Emit Diagnostics Failed."),
         }
     }
@@ -622,6 +649,11 @@ impl DiagnosticHandlerInner {
             .iter()
             .map(|d| Ok(emit_diagnostic_to_uncolored_text(d)?))
             .collect()
+    }
+
+    /// Emit the [`index`]th diagnostic into string and return.
+    pub(crate) fn emit_nth_diag_into_string(&self, index: usize) -> Option<Result<String>> {
+        self.diagnostics.get(index).map(|d|emit_diagnostic_to_uncolored_text(d))
     }
 
     /// Emit the diagnostic messages generated from error to to terminal stderr.

--- a/compiler_base/error/src/diagnostic/diagnostic_handler.rs
+++ b/compiler_base/error/src/diagnostic/diagnostic_handler.rs
@@ -285,9 +285,9 @@ impl DiagnosticHandler {
     }
 
     /// Emit the [`index`]th diagnostics into strings and return.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```rust
     /// use compiler_base_error::DiagnosticStyle;
     /// use compiler_base_error::diagnostic_handler::DiagnosticHandler;
@@ -653,7 +653,9 @@ impl DiagnosticHandlerInner {
 
     /// Emit the [`index`]th diagnostic into string and return.
     pub(crate) fn emit_nth_diag_into_string(&self, index: usize) -> Option<Result<String>> {
-        self.diagnostics.get(index).map(|d|emit_diagnostic_to_uncolored_text(d))
+        self.diagnostics
+            .get(index)
+            .map(|d| emit_diagnostic_to_uncolored_text(d))
     }
 
     /// Emit the diagnostic messages generated from error to to terminal stderr.

--- a/compiler_base/error/src/emitter.rs
+++ b/compiler_base/error/src/emitter.rs
@@ -447,7 +447,7 @@ pub fn emit_diagnostic_to_uncolored_text(diag: &Diagnostic<DiagnosticStyle>) -> 
 
 /// Used to save the result of emit into a [`String`],
 /// because trait [`Write`] and [`Send`] cannot be directly implemented by [`String`].
-struct EmitResultText {
+pub(crate) struct EmitResultText {
     test_res: String,
 }
 

--- a/compiler_base/error/src/tests.rs
+++ b/compiler_base/error/src/tests.rs
@@ -146,8 +146,9 @@ mod test_errors {
 
 mod test_emitter {
     use crate::{
-        components::Label, emit_diagnostic_to_uncolored_text, emitter::Destination, Diagnostic,
-        Emitter, EmitterWriter,
+        components::Label, diagnostic_handler::DiagnosticHandler,
+        emit_diagnostic_to_uncolored_text, emitter::Destination, Diagnostic, Emitter,
+        EmitterWriter,
     };
     use std::io::{self, Write};
     use termcolor::Ansi;


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kusionstack/KCLVM/kclvm-parser 
-->

compiler_base_error.

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->
add method "emit_all_diags_into_string" for 'DiagnosticHandler' to emit all diagnostics into strings.
add method "emit_nth_diag_into_string" for 'DiagnosticHandler' to emit one diagnostics into string.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
None
```
