### PR TITLE
feat: remove top level unification using the override operator.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ build:
 release:
 	${PWD}/run.sh -a release
 
+.PHONY: check
+check:
+	make -C ./kclvm check
+
 .PHONY: test
 test:
 	make -C ./kclvm test

--- a/kclvm/sema/src/pre_process/config.rs
+++ b/kclvm/sema/src/pre_process/config.rs
@@ -1,3 +1,4 @@
+use crate::info::is_private_field;
 use indexmap::{IndexMap, IndexSet};
 use kclvm_ast::walker::MutSelfMutWalker;
 use kclvm_ast::{ast, walk_if_mut};
@@ -140,12 +141,18 @@ impl ConfigMergeTransformer {
                                     if target.node.names.len() == 1 {
                                         let name = &target.node.names[0];
                                         match name_declaration_mapping.get_mut(name) {
-                                            Some(declarations) => declarations.push((
-                                                module.filename.to_string(),
-                                                module_id,
-                                                i,
-                                                ConfigMergeKind::Override,
-                                            )),
+                                            Some(declarations) => {
+                                                // A hidden var is mutable.
+                                                if is_private_field(name) {
+                                                    declarations.clear();
+                                                    declarations.push((
+                                                        module.filename.to_string(),
+                                                        module_id,
+                                                        i,
+                                                        ConfigMergeKind::Override,
+                                                    ))
+                                                }
+                                            }
                                             None => {
                                                 name_declaration_mapping.insert(
                                                     name.to_string(),

--- a/test/grammar/unification/append_0/main.k
+++ b/test/grammar/unification/append_0/main.k
@@ -4,13 +4,13 @@ schema Main:
 schema Config:
     main: Main
 
-config = Config {
+config: Config {
     main: Main {
         env: ["s1"]
     }
 }
 
-config = Config {
+config: Config {
     main: Main {
         env += ["s2"]
     }

--- a/test/grammar/unification/append_1/main.k
+++ b/test/grammar/unification/append_1/main.k
@@ -1,10 +1,10 @@
 schema Main:
     env: [str]
 
-main = Main {
+main: Main {
     env: ["s1"]
 }
 
-main = Main {
+main: Main {
     env += ["s2"]
 }

--- a/test/grammar/unification/collection_if_0/main.k
+++ b/test/grammar/unification/collection_if_0/main.k
@@ -2,12 +2,12 @@ schema Person:
     name: str
     age: int
 
-alice = Person {
+alice: Person {
     if True:
         name: "Alice"
 }
 
-alice = Person {
+alice: Person {
     if True:
         age = 18
 }

--- a/test/grammar/unification/collection_if_1/main.k
+++ b/test/grammar/unification/collection_if_1/main.k
@@ -2,17 +2,17 @@ schema Person:
     name: str
     age: int
 
-alice = Person {
+alice: Person {
     if True:
         name: "Alice"
 }
 
-alice = Person {
+alice: Person {
     if True:
         age = 18
 }
 
-alice = Person {
+alice: Person {
     age = 10
 }
 

--- a/test/grammar/unification/empty_0/main.k
+++ b/test/grammar/unification/empty_0/main.k
@@ -2,8 +2,8 @@ schema Person:
     name?: str = None
     age?: int = None
 
-alice = Person {}
-alice = Person {}
+alice: Person {}
+alice: Person {}
 
 name = alice.name or "Alice"
 age = alice.age or 18

--- a/test/grammar/unification/empty_1/main.k
+++ b/test/grammar/unification/empty_1/main.k
@@ -2,9 +2,9 @@ schema Person:
     name?: str = None
     age?: int = None
 
-alice = Person {}
+alice: Person {}
 
-alice = Person {}
+alice: Person {}
 
 name = alice.name or "Alice"
 age = alice.age or 18

--- a/test/grammar/unification/multi_file_compile_0/main.k
+++ b/test/grammar/unification/multi_file_compile_0/main.k
@@ -3,7 +3,7 @@ schema Config:
     args: [str]
     labels: {str:}
 
-config = Config {
+config: Config {
     name: "config1"
     args: ["kcl", "main.k"]
     labels.key1: "value1"

--- a/test/grammar/unification/multi_file_compile_0/stack.k
+++ b/test/grammar/unification/multi_file_compile_0/stack.k
@@ -1,3 +1,3 @@
-config = Config {
+config: Config {
     name = "config2"
 }

--- a/test/grammar/unification/multi_file_compile_1/main.k
+++ b/test/grammar/unification/multi_file_compile_1/main.k
@@ -3,7 +3,7 @@ schema Config:
     args: [str]
     labels: {str:}
 
-config = Config {
+config: Config {
     name: "config1"
     args: ["kcl", "main.k"]
     labels.key1: "value1"

--- a/test/grammar/unification/multi_file_compile_1/stack.k
+++ b/test/grammar/unification/multi_file_compile_1/stack.k
@@ -1,4 +1,4 @@
 _NAME = "config2"
-config = Config {
+config: Config {
     name = _NAME
 }

--- a/test/grammar/unification/nest_var_0/main.k
+++ b/test/grammar/unification/nest_var_0/main.k
@@ -2,18 +2,18 @@ schema Config:
     args: [str]
     labels: {str:}
 
-config = Config {
+config: Config {
     args: ["kcl", "main.k"]
     labels.key1: "value1"
 }
 
-config = Config {
+config: Config {
     labels: {
         key2: "value2"
     }
 }
 
-config = Config {
+config: Config {
     "labels": {
         "key3": "value3"
     }

--- a/test/grammar/unification/nest_var_1/main.k
+++ b/test/grammar/unification/nest_var_1/main.k
@@ -10,13 +10,13 @@ schema Config:
     labels: {str:}
     name: Name
 
-config = Config {
+config: Config {
     args: ["kcl", "main.k"]
     labels.key1: "value1"
     name.name.name: "name"
 }
 
-config = Config {
+config: Config {
     labels: {
         key2: "value2"
     }

--- a/test/grammar/unification/override_0/main.k
+++ b/test/grammar/unification/override_0/main.k
@@ -3,12 +3,12 @@ schema Person:
     age: int
     hc: [int]
 
-alice = Person {
+alice: Person {
     name: "Alice"
     hc: [1, 2]
 }
 
-alice = Person {
+alice: Person {
     age: 18
     hc = [2]
 }

--- a/test/grammar/unification/override_1/main.k
+++ b/test/grammar/unification/override_1/main.k
@@ -3,7 +3,7 @@ schema Person:
     age: int
     env: [{str:}]
 
-alice = Person {
+alice: Person {
     name: "Alice"
     env: [{
         name: "key1"
@@ -14,7 +14,7 @@ alice = Person {
     }]
 }
 
-alice = Person {
+alice: Person {
     age: 18
     env = [{
         name: "key2"

--- a/test/grammar/unification/schema_simple_0/main.k
+++ b/test/grammar/unification/schema_simple_0/main.k
@@ -2,10 +2,10 @@ schema Person:
     name: str
     age: int
 
-alice = Person {
+alice: Person {
     name: "Alice"
 }
 
-alice = Person {
+alice: Person {
     age: 18
 }

--- a/test/grammar/unification/schema_simple_1/main.k
+++ b/test/grammar/unification/schema_simple_1/main.k
@@ -3,15 +3,15 @@ schema Config:
     age?: int
     hc: [int]
 
-config = Config {
+config: Config {
     name: "Alice"
 }
 
-config = Config {
+config: Config {
     age: 18
 }
 
-config = Config {
+config: Config {
     hc: [1]
 }
 

--- a/test/grammar/unification/schema_simple_2/main.k
+++ b/test/grammar/unification/schema_simple_2/main.k
@@ -3,14 +3,14 @@ schema Config:
     age?: int
     hc: [int]
 
-config = Config {
+config: Config {
     name: "Alice"
 }
 age = 18
-config = Config {
+config: Config {
     age: age
 }
 
-config = Config {
+config: Config {
     hc: [1]
 }

--- a/test/grammar/unification/schema_simple_3/main.k
+++ b/test/grammar/unification/schema_simple_3/main.k
@@ -13,12 +13,12 @@ _main = Main {
     args: ["1"]
 }
 
-config = Config {
+config: Config {
     name: "Alice"
     main: _main
 }
 
-config = Config {
+config: Config {
     age: 18
     main: Main {
         env = ["789", "456"]

--- a/test/grammar/unification/str_interpolation/main.k
+++ b/test/grammar/unification/str_interpolation/main.k
@@ -3,8 +3,8 @@ schema Person:
     age: int
 
 key = "age"
-_alice = Person {
+_alice: Person {
     name: "Alice"
 }
-_alice = Person {"${key}": 18}
+_alice: Person {"${key}": 18}
 alice = _alice

--- a/test/grammar/unification/subscript_0/main.k
+++ b/test/grammar/unification/subscript_0/main.k
@@ -2,11 +2,11 @@ schema Person:
     name: str
     age: int
 
-alice = Person {
+alice: Person {
     name: "Alice"
 }
 
-alice = Person {
+alice: Person {
     age: 18
 }
 

--- a/test/grammar/unification/subscript_1/main.k
+++ b/test/grammar/unification/subscript_1/main.k
@@ -2,12 +2,12 @@ schema Person:
     name: str
     age: int
 
-alice = Person {
+alice: Person {
     name: "Alice"
     age: 18
 }
 
-alice = Person {}
+alice: Person {}
 
 name = alice.name
 age = alice.age

--- a/test/grammar/unification/unpack_0/main.k
+++ b/test/grammar/unification/unpack_0/main.k
@@ -7,11 +7,11 @@ _base = {
     age = 18
 }
 
-alice = Person {
+alice: Person {
     **_base
 }
 
-alice = Person {
+alice: Person {
     name = "Alice"
     age = 18
 }

--- a/test/grammar/unification/unpack_1/main.k
+++ b/test/grammar/unification/unpack_1/main.k
@@ -7,11 +7,11 @@ _base = {
     age = 10
 }
 
-alice = Person {
+alice: Person {
     age: 18
 }
 
-alice = Person {
+alice: Person {
     **_base
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y 

feat: remove top-level unification using the override operator.

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kusionstack/KCLVM/kclvm-parser 
-->

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

Language simplification: The schema with the same name as top level uses `=` to indicate override, uses `:` to indicate merging, and reports an error when overriding the immutable variable `=`.

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [ ] N
- [x] Y 

Language simplification: The schema with the same name as top level uses `=` to indicate override, uses `:` to indicate merging, and reports an error when overriding the immutable variable `=`.

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [x] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

+ test/grammar/unification/**/*.k

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
None
```
