### PR TITLE
fix: fix a bug in the path format of argument '-E/--external'.

### DIFF
--- a/kclvm/cmd/src/tests.rs
+++ b/kclvm/cmd/src/tests.rs
@@ -1,4 +1,6 @@
-use crate::{app, fmt::fmt_command, settings::build_settings, vet::vet_command};
+use crate::{
+    app, fmt::fmt_command, settings::build_settings, util::hashmaps_from_matches, vet::vet_command,
+};
 
 const ROOT_CMD: &str = "kclvm_cli";
 
@@ -96,4 +98,74 @@ fn settings_arguments(path: std::path::PathBuf) -> Vec<String> {
         "-S".to_string(),
         "a.b.c".to_string(),
     ]
+}
+
+#[test]
+fn test_external_cmd() {
+    let matches = app().get_matches_from(&[ROOT_CMD, "run", "-E", "test_name=test_path"]);
+    let matches = matches.subcommand_matches("run").unwrap();
+    let pair = hashmaps_from_matches(matches, "package_map")
+        .unwrap()
+        .unwrap();
+    assert_eq!("{\"test_name\": \"test_path\"}", format!("{:?}", pair));
+}
+
+#[test]
+fn test_multi_external_cmd() {
+    let matches = app().get_matches_from(&[
+        ROOT_CMD,
+        "run",
+        "-E",
+        "test_name=test_path",
+        "-E",
+        "test_name1=test_path1",
+    ]);
+    let matches = matches.subcommand_matches("run").unwrap();
+    let pair = hashmaps_from_matches(matches, "package_map")
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        "{\"test_name1\": \"test_path1\", \"test_name\": \"test_path\"}",
+        format!("{:?}", pair)
+    );
+}
+
+#[test]
+fn test_multi_external_with_same_key_cmd() {
+    let matches = app().get_matches_from(&[
+        ROOT_CMD,
+        "run",
+        "-E",
+        "test_name=test_path",
+        "-E",
+        "test_name=test_path1",
+    ]);
+    let matches = matches.subcommand_matches("run").unwrap();
+    let pair = hashmaps_from_matches(matches, "package_map")
+        .unwrap()
+        .unwrap();
+    assert_eq!("{\"test_name\": \"test_path1\"}", format!("{:?}", pair));
+}
+
+#[test]
+fn test_external_cmd_invalid() {
+    let invalid_cases: [&str; 1] = [
+        "test_nametest_path",
+        "test_name=test_path=test_suffix",
+        "=test_path",
+        "test_name=",
+        "=test_name=test_path=",
+    ];
+    for case in invalid_cases {
+        let matches = app().get_matches_from(&[ROOT_CMD, "run", "-E", case]);
+        let matches = matches.subcommand_matches("run").unwrap();
+        match hashmaps_from_matches(matches, "package_map").unwrap() {
+            Ok(_) => {
+                panic!("unreachable code.")
+            }
+            Err(err) => {
+                assert!(format!("{:?}", err).contains("Invalid value for top level arguments"));
+            }
+        };
+    }
 }

--- a/kclvm/cmd/src/tests.rs
+++ b/kclvm/cmd/src/tests.rs
@@ -149,7 +149,7 @@ fn test_multi_external_with_same_key_cmd() {
 
 #[test]
 fn test_external_cmd_invalid() {
-    let invalid_cases: [&str; 1] = [
+    let invalid_cases: [&str; 5] = [
         "test_nametest_path",
         "test_name=test_path=test_suffix",
         "=test_path",

--- a/kclvm/cmd/src/tests.rs
+++ b/kclvm/cmd/src/tests.rs
@@ -107,7 +107,9 @@ fn test_external_cmd() {
     let pair = hashmaps_from_matches(matches, "package_map")
         .unwrap()
         .unwrap();
-    assert_eq!("{\"test_name\": \"test_path\"}", format!("{:?}", pair));
+    assert_eq!(pair.len(), 1);
+    assert!(pair.contains_key("test_name"));
+    assert_eq!(pair.get("test_name").unwrap(), "test_path");
 }
 
 #[test]
@@ -124,10 +126,12 @@ fn test_multi_external_cmd() {
     let pair = hashmaps_from_matches(matches, "package_map")
         .unwrap()
         .unwrap();
-    assert_eq!(
-        "{\"test_name1\": \"test_path1\", \"test_name\": \"test_path\"}",
-        format!("{:?}", pair)
-    );
+
+    assert_eq!(pair.len(), 2);
+    assert!(pair.contains_key("test_name"));
+    assert!(pair.contains_key("test_name1"));
+    assert_eq!(pair.get("test_name").unwrap(), "test_path");
+    assert_eq!(pair.get("test_name1").unwrap(), "test_path1");
 }
 
 #[test]
@@ -144,7 +148,9 @@ fn test_multi_external_with_same_key_cmd() {
     let pair = hashmaps_from_matches(matches, "package_map")
         .unwrap()
         .unwrap();
-    assert_eq!("{\"test_name\": \"test_path1\"}", format!("{:?}", pair));
+    assert_eq!(pair.len(), 1);
+    assert!(pair.contains_key("test_name"));
+    assert_eq!(pair.get("test_name").unwrap(), "test_path1");
 }
 
 #[test]

--- a/kclvm/cmd/src/util.rs
+++ b/kclvm/cmd/src/util.rs
@@ -1,7 +1,5 @@
-use anyhow::bail;
 use anyhow::Result;
 use clap::ArgMatches;
-use kclvm_driver::arguments::parse_key_value_pair;
 use std::collections::HashMap;
 
 #[inline]

--- a/kclvm/cmd/src/util.rs
+++ b/kclvm/cmd/src/util.rs
@@ -22,10 +22,15 @@ pub(crate) fn hashmaps_from_matches(
     matches.values_of(key).map(|files| {
         files
             .into_iter()
-            .map(|s| match parse_key_value_pair(s) {
-                Ok(pair) => Ok((pair.key, pair.value)),
-                Err(_) => {
-                    bail!("Invalid arguments format '-E, --external', use'kclvm_cli run --help' for more help.")
+            .map(|s| {
+                let split_values = s.split('=').collect::<Vec<&str>>();
+                if split_values.len() == 2
+                    && !split_values[0].trim().is_empty()
+                    && !split_values[1].trim().is_empty()
+                {
+                    Ok((split_values[0].to_string(), split_values[1].to_string()))
+                } else {
+                    Err(anyhow::anyhow!("Invalid value for top level arguments"))
                 }
             })
             .collect::<Result<HashMap<String, String>>>()


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kusionstack/KCLVM/kclvm-parser 
-->

kclvm_cli.

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

When the `-E/--external` arguments of the `kclvm_cli run` command is used, the parsed path format is incorrect. As a result, the package in the corresponding path cannot be found.

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
None
```
